### PR TITLE
`coupling_coeffs` does not return basis with correct dimensionality

### DIFF
--- a/src/O3.jl
+++ b/src/O3.jl
@@ -326,7 +326,7 @@ function _coupling_coeffs(L::Int64, ll::SVector{N, Int64}, nn::SVector{N, Int64}
         return UMatrix, MM
     else
         U, S, V = svd(gram(FMatrix))
-        rk = rank(Diagonal(S); rtol =  1e-12)
+        rk = findall(x -> x > 1e-12, S) |> length # rank(Diagonal(S); rtol =  1e-12) # Somehow rank is not working properly here
         # return the RE-PI coupling coeffs
         return Diagonal(S[1:rk]) * (U[:, 1:rk]' * UMatrix), MM
     end


### PR DESCRIPTION
There are cases where `coupling_coeffs` returns wrong dimensionalities. It happens when a set of (nn,ll) doesn't lead to any feasible basis, but owing to the way the rank of the S matrix in the SVD is counted right now, the function returns some meaningless zero bases instead of returning a desired $0\times$ #MM coupling coefficient matrix. 

An example:

```julia
using EquivariantTensors.O3: _coupling_coeffs, coupling_coeffs
using StaticArrays, LinearAlgebra

ll = SA[1,1,1]
nn = SA[2,2,2]
L = 2

C,M = coupling_coeffs(L,ll,nn) # user-faced coupling_coeffs
C_int,M_int = _coupling_coeffs(L,ll,nn) # inter-function

# The above are consistent
C == C_int 
M == M_int

# However, the dimensionality is wrong
norm(C) <= 1e-20 # indicating zeros bases
size(C) == 0 # it is false
```

The problem lies in that

```julia
rk = rank(Diagonal(S); rtol =  1e-12)
```
refuses to return the correct rank of S (or equivalently, the rank of the FMatrix).

This PR aims for fixing this problem, by evaluating `rk` differently, as 

```julia
rk = findall(x -> x > 1e-12, S) |> length
```