### PR TITLE
new implementation of _real_clebschgordan

### DIFF
--- a/examples/ace/simple_ace_equivariant2.jl
+++ b/examples/ace/simple_ace_equivariant2.jl
@@ -11,7 +11,7 @@ using Zygote
 
 ##
 
-struct SimpleACE3{T, RB, YB, BB0, BB2, TT}
+struct SimpleACE4{T, RB, YB, BB0, BB2, TT}
    rbasis::RB      # radial embedding Rn
    ybasis::YB      # angular embedding Ylm
    symbasis0::BB0    # symmetric basis 
@@ -21,7 +21,7 @@ struct SimpleACE3{T, RB, YB, BB0, BB2, TT}
    trans::TT
 end
 
-function evaluate(m::SimpleACE3, 𝐫::AbstractVector{<: SVector{3}}; basis = complex)
+function evaluate(m::SimpleACE4, 𝐫::AbstractVector{<: SVector{3}}; basis = complex)
    # [1] Embeddings: evaluate the Rn and Ylm embeddings
    #   Rn[j] = Rn(norm(𝐫[j])), Ylm[j] = Ylm(Rs[j])
    Rn = P4ML.evaluate(m.rbasis, norm.(𝐫))
@@ -80,7 +80,7 @@ nnll_long = ET.sparse_nnll_set(; L = 2, ORD = ORD,
 # putting together everything we've construced we can now generate the model 
 # here we give the model some random parameters just for testing. 
 #
-model = SimpleACE3(rbasis, ybasis, 𝔹basis0, 𝔹basis2, 
+model = SimpleACE4(rbasis, ybasis, 𝔹basis0, 𝔹basis2, 
                    randn(length(𝔹basis0)), randn(length(𝔹basis2)), 
                    ET.O3.TYVec2YMat(1, 1; basis=complex))
 
@@ -129,7 +129,7 @@ nnll_long = ET.sparse_nnll_set(; L = 2, ORD = ORD,
             Ylm_spec = Ylm_spec, 
             basis = real )
 
-model = SimpleACE3(rbasis, ybasis, 𝔹basis0, 𝔹basis2, 
+model = SimpleACE4(rbasis, ybasis, 𝔹basis0, 𝔹basis2, 
                   randn(length(𝔹basis0)),  randn(length(𝔹basis2)), 
                   ET.O3.TYVec2YMat(1, 1; basis=real))
 

--- a/src/O3/O3_utils.jl
+++ b/src/O3/O3_utils.jl
@@ -54,29 +54,24 @@ function cg(l1, m1, l2, m2, L, M, basis::typeof(real))
 end
  
 function _real_clebschgordan(l1, m1, l2, m2, λ, νp)
-   C1 = Ctran(l1)
-   C2 = Ctran(l2)
-   Cλ = Ctran(λ)
- 
-   val = 0.0 + 0im
-   for n1 = -l1:l1
-      for n2 = -l2:l2
-         ν = n1 + n2
-         if abs(ν) <= λ
-            cg = PartialWaveFunctions.clebschgordan(l1, n1, l2, n2, λ, ν)
- 
-            i1 = m1 + l1 + 1
-            i2 = (l2 - m2) + 1  
-            j1 = n1 + l1 + 1
-            j2 = (l2 - n2) + 1 
-            k1 = νp + λ + 1
-            k2 = ν + λ + 1
- 
-            val += C1[i1, j1] * conj(C2[i2, j2]) * conj(Cλ[k1, k2]) * cg
-         end
-      end
+   result = 0.0 + 0im
+
+   # Only n values with |n| = |m| contribute due to Ctran(m, n) selection rule
+   n1_values = m1 == 0 ? [0] : [-m1, m1]
+   n2_values = m2 == 0 ? [0] : [-m2, m2]
+
+   for n1 in n1_values
+       for n2 in n2_values
+           ν = n1 + n2
+           # Selection rules: |ν| must be ≤ λ and match |νp|
+           if abs(ν) ≤ λ && abs(ν) == abs(νp)
+               cg = PartialWaveFunctions.clebschgordan(l1, n1, l2, n2, λ, ν)
+               result += Ctran(m1, n1) * conj(Ctran(-m2, -n2)) * conj(Ctran(νp, ν)) * cg
+           end
+       end
    end
-   return real(val)
+
+   return real(result)
 end
  
 


### PR DESCRIPTION
Replace C[i,j] with Ctran(m, n) to avoid building full matrices Ctran, and restrict loops to |n| = |m| to reduce computation.