### PR TITLE
Robust invmap

### DIFF
--- a/benchmark/profile_symmop.jl
+++ b/benchmark/profile_symmop.jl
@@ -16,7 +16,7 @@ ybasis = P4ML.complex_sphericalharmonics(maxl)
 Ylm_spec = P4ML.natural_indices(ybasis)
 
 # generate the nnll basis pre-specification
-nnll_long = ET.sparse_nnll_set(; L = 0, ORD = ORD, 
+nnll_spec = ET.sparse_nnll_set(; L = 0, ORD = ORD, 
                   minn = 0, maxn = Dtot, maxl = maxl, 
                   level = bb -> sum((b.n + b.l) for b in bb; init=0), 
                   maxlevel = Dtot)
@@ -27,7 +27,7 @@ nnll_long = ET.sparse_nnll_set(; L = 0, ORD = ORD,
 # else will be handled by the symmetrization operator within the model 
 # construction; along the way we will also prune the nnll list.
 @time 𝔹basis = ET.sparse_equivariant_tensor(; 
-            L = 0, mb_spec = nnll_long, 
+            L = 0, mb_spec = nnll_spec, 
             Rnl_spec = Rn_spec, 
             Ylm_spec = Ylm_spec, 
             basis = complex, )

--- a/examples/ace/simple_ace.jl
+++ b/examples/ace/simple_ace.jl
@@ -94,7 +94,7 @@ myfilter = ii -> begin
       nn, ll, mm = ii2bb(ii);
       return ( (sum(nn + ll; init=0) <= Dtot) &&  # total degree trunction
                iseven(sum(ll; init=0)) &&         # reflection-invariance
-               (length(mm) == 0 || ET.O3.m_filter(mm, 0, flag=:SpheriCart)) &&         # rotation-invariance
+               (length(mm) == 0 || ET.O3.mm_filter(mm, 0, flag=:SpheriCart)) &&         # rotation-invariance
                sum(ii) > 0 )           # drop 0-corr sure to bug 
    end 
 

--- a/examples/ace/simple_ace_equivariant.jl
+++ b/examples/ace/simple_ace_equivariant.jl
@@ -26,7 +26,7 @@ function evaluate(m::SimpleACE3, 𝐫::AbstractVector{<: SVector{3}})
    Rn = P4ML.evaluate(m.rbasis, norm.(𝐫))
    Ylm = P4ML.evaluate(m.ybasis, 𝐫)
    # [2] feed the Rn, Ylm embeddings through the sparse ACE model 
-   𝔹 = ET.evaluate(m.symbasis, Rn, Ylm)
+   𝔹, = ET.evaluate(m.symbasis, Rn, Ylm)
    # [3] the model output value is the dot product with the parameters 
    return sum(m.params .* 𝔹)
 end

--- a/src/ace/sparse_ace_utils.jl
+++ b/src/ace/sparse_ace_utils.jl
@@ -147,6 +147,8 @@ end
 takes an nnll spec and generates a complete list of all possible nnllmm
 """
 function _auto_nnllmm_spec(nnll_spec)
+   _sortby(bb) = (length(bb), bb) 
+
    NT_NLM = typeof( (n = 0, l = 0, m = 0) ) 
    nnllmm = Vector{NT_NLM}[] 
    for bb in nnll_spec
@@ -156,7 +158,7 @@ function _auto_nnllmm_spec(nnll_spec)
                          for (b, m) in zip(bb, mm) ] )
       end
    end
-   return nnllmm
+   return unique(sort( sort!.(nnllmm), by = _sortby ))
 end
 
 

--- a/src/utils/invmap.jl
+++ b/src/utils/invmap.jl
@@ -1,12 +1,33 @@
 
+struct FFInvMap{T} 
+   a::Vector{T} 
+   p::Vector{Int} 
+end 
+
+Base.getindex(m::FFInvMap{T}, v::T) where {T} = m.p[searchsortedfirst(m.a, v)]
 
 """
       invmap(a::AbstractVector)
 
-Return a dictionary that maps the elements of a to their indices, to accelerate 
-if there are many repeated searches into `a`.
+Returns a structure that makes looking up the index of an element in a vector 
+convenient and fast. Assumes that elements of `a` are unique.
+```julia
+inva = invmap(a) 
+inva[a[i]] == i  # true for all i
+```
 """
 function invmap(a::AbstractVector)
+   p = sortperm(a) 
+   b = a[p]
+   if !allunique(b)
+      throw(ArgumentError("invmap: Elements of a must be unique"))
+   end
+   return FFInvMap(b, p)
+end
+
+
+# Backup function which is probably not needed anymore. 
+function dict_invmap(a::AbstractVector)
    inva = Dict{eltype(a), Int}()
    for i = 1:length(a) 
       inva[a[i]] = i 

--- a/src/utils/invmap.jl
+++ b/src/utils/invmap.jl
@@ -5,7 +5,7 @@ struct FFInvMap{T, HF}
    hashfcn::HF
 end 
 
-Base.getindex(m::FFInvMap{T}, v::T) where {T} = 
+Base.getindex(m::FFInvMap, v) = 
       m.p[searchsortedfirst(m.h, m.hashfcn(v))]
 
 """

--- a/src/utils/invmap.jl
+++ b/src/utils/invmap.jl
@@ -1,10 +1,12 @@
 
-struct FFInvMap{T} 
-   a::Vector{T} 
+struct FFInvMap{T, HF} 
+   h::Vector{T} 
    p::Vector{Int} 
+   hashfcn::HF
 end 
 
-Base.getindex(m::FFInvMap{T}, v::T) where {T} = m.p[searchsortedfirst(m.a, v)]
+Base.getindex(m::FFInvMap{T}, v::T) where {T} = 
+      m.p[searchsortedfirst(m.h, m.hashfcn(v))]
 
 """
       invmap(a::AbstractVector)
@@ -16,13 +18,13 @@ inva = invmap(a)
 inva[a[i]] == i  # true for all i
 ```
 """
-function invmap(a::AbstractVector)
+function invmap(a::AbstractVector, hashfcn = identity)
    p = sortperm(a) 
-   b = a[p]
-   if !allunique(b)
+   h = [ hashfcn(a[p[i]]) for i in 1:length(a) ]
+   if !allunique(h)
       throw(ArgumentError("invmap: Elements of a must be unique"))
    end
-   return FFInvMap(b, p)
+   return FFInvMap(h, p, hashfcn)
 end
 
 

--- a/src/utils/symmop.jl
+++ b/src/utils/symmop.jl
@@ -34,7 +34,8 @@ function symmetrisation_matrix(L::Integer, mb_spec;
    # Vector{Vector{NT_NLM}}
    𝔸spec = _auto_nnllmm_spec(mb_spec)
    
-   # convert an element of 𝔸spec to nn, ll, mm 
+   # convert an element of 𝔸spec to nn, ll, mm, which is the format 
+   # used by the coupling_coeffs function 
    function _vecnt2nnllmm(bb)
       nn = [ b.n for b in bb ]
       ll = [ b.l for b in bb ]
@@ -43,6 +44,7 @@ function symmetrisation_matrix(L::Integer, mb_spec;
    end
 
    # convert nn, ll, mm or bb to a unique search key for searching in 𝔸spec
+   _bb_key(nnllmm::Tuple) = _bb_key(nnllmm[1], nnllmm[2], nnllmm[3])
    _bb_key(nn, ll, mm) = sort([ (n, l, m) for (n, l, m) in zip(nn, ll, mm) ])
    _bb_key(bb::Vector{<: NamedTuple}) = sort([ (b.n, b.l, b.m) for b in bb ])
 
@@ -66,10 +68,10 @@ function symmetrisation_matrix(L::Integer, mb_spec;
    num𝔹 = 0 
    for (nn, ll) in nnll
       # here the kwargs... should be PI and basis 
-      cc, MM = O3new.coupling_coeffs(L, ll, nn; kwargs...)
+      cc, MM = O3.coupling_coeffs(L, ll, nn; kwargs...)
       num_b = size(cc, 1)   
       # lookup the corresponding (nn, ll, mm) in the 𝔸 specification 
-      idx_𝔸 = [inv_𝔸spec[_bb_key(nn, ll, mm)] for mm in MM] 
+      idx_𝔸 = [inv_𝔸spec[ (nn, ll, mm) ] for mm in MM] 
       # add the new basis functions to the triplet format
       for q = 1:num_b 
          num𝔹 += 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ isdefined(Main, :___UTILS_FOR_TESTS___) || include("utils/utils_testO3.jl")
 
 @testset "Utils" begin 
     @testset "SetProduct" begin include("utils/test_setproduct.jl"); end
+    @testset "InvMap" begin include("utils/test_invmap.jl"); end
 end
 
 @testset "ACE" begin 

--- a/test/test_coupling.jl
+++ b/test/test_coupling.jl
@@ -67,6 +67,7 @@ for L = 0:Lmax
    nnll_list = ultra_short_nnll_list
 
    for (itest, (nn, ll)) in enumerate(nnll_list)
+      local N 
       nn = shuffle(nn)
       ll = shuffle(ll)
       # @show nn, ll
@@ -145,6 +146,7 @@ for L = 0:Lmax
    @info("Using short ll list for testing the case L = $L with the absence of nn")
    ll_list = [ nnll_list[i][2] for i in 1:length(nnll_list) ] |> unique
    for (itest, ll) in enumerate(ll_list)
+      local N 
       N = length(ll)
 
       Ure, Mll = coupling_coeffs(L, ll; PI = false) # cSH based re_basis

--- a/test/utils/test_invmap.jl
+++ b/test/utils/test_invmap.jl
@@ -1,0 +1,34 @@
+
+using EquivariantTensors, Test 
+import EquivariantTensors as ET 
+
+##
+
+function rand_b() 
+   l = rand(1:12) 
+   return (n = rand(1:20), l = rand(1:10), m = rand(-l:l) )
+end
+
+rand_bb() = sort( [ rand_b() for _ = 1:rand(1:4) ] )
+
+##
+
+@info("Testing invmap")
+
+N = 100_000 
+A = unique( [ rand_bb() for _ = 1:N ] )
+
+# @time 
+invA = ET.invmap(A)
+
+println(@test(
+   all( invA[a] == i for (i, a) in enumerate(A) )
+   ))
+
+B = [ A[rand(1:10)] for _ = 1:100 ]
+try 
+   invB = ET.invmap(B)
+   @test false 
+catch e 
+   println(@test typeof(e) == ArgumentError)
+end


### PR DESCRIPTION
fixes #27; it replaced the dictionary with a `searchsortedfirst`. This seems fast and robust. If there this becomes the bottleneck again for symmop then we can revisit the idea of using a hash. (it really should work with a hash, just makes me nervous...)