### PR TITLE
Fix partial bb gradient

### DIFF
--- a/examples/ace/fail_Zygote.jl
+++ b/examples/ace/fail_Zygote.jl
@@ -66,7 +66,7 @@ ps, st = Lux.setup(rng, model)
 φ, _ = Lux.apply(model, 𝐫, ps, st)
 
 # ==========================
-# Pullback Test (fails currently)
+# Pullback Test (should succeed)
 # ==========================
 val, pb = Zygote.pullback(𝐫 -> Lux.apply(model, 𝐫, ps, st)[1], 𝐫)
 pb(val)
@@ -116,4 +116,4 @@ val2, pb2 = Zygote.pullback(φ1 -> Lux.apply(model2, φ1, ps2, st2)[1], φ1)
 # ==========================
 val1, pb1 = Zygote.pullback(𝐫 -> Lux.apply(model1, 𝐫, ps1, st1)[1], 𝐫)
 pb1(val1)         # should succeed
-pb1(∂BB)          # fails
+pb1(∂BB)          # should succeed

--- a/src/ace/sparse_ace.jl
+++ b/src/ace/sparse_ace.jl
@@ -151,7 +151,8 @@ function whatalloc(::typeof(pullback!),
                    )
    # TODO: may need to check the type of ∂BB too, but this is a bit 
    #       tricky because of the SVectors that can be in there...
-   TA = promote_type(eltype(Rnl), eltype(eltype(Ylm)))
+   TB = eltype.(eltype.(∂BB))
+   TA = promote_type(eltype(Rnl), eltype(Ylm), TB...)
    return (TA, size(Rnl)...), (TA, size(Ylm)...)
 end
 


### PR DESCRIPTION
Fixed the `whatalloc` in issue #38 as
```julia 
function whatalloc(::typeof(pullback!),  
                   ∂BB, tensor::SparseACE, Rnl, Ylm
                   )
   # TODO: may need to check the type of ∂BB too, but this is a bit 
   #       tricky because of the SVectors that can be in there...
   TB = eltype.(eltype.(∂BB))
   TA = promote_type(eltype(Rnl), eltype(Ylm), TB...)
   return (TA, size(Rnl)...), (TA, size(Ylm)...)
end
```