### PR TITLE
Performance Fixes to Symm Op

### DIFF
--- a/benchmark/profile_symmop.jl
+++ b/benchmark/profile_symmop.jl
@@ -1,3 +1,4 @@
+using Pkg; Pkg.activate(joinpath(@__DIR__(), ".."))
 import Polynomials4ML as P4ML 
 import EquivariantTensors as ET
 using StaticArrays, SparseArrays, LinearAlgebra, Zygote, Random

--- a/benchmark/profile_symmop.jl
+++ b/benchmark/profile_symmop.jl
@@ -30,11 +30,13 @@ nnll_spec = ET.sparse_nnll_set(; L = 0, ORD = ORD,
             L = 0, mb_spec = nnll_spec, 
             Rnl_spec = Rn_spec, 
             Ylm_spec = Ylm_spec, 
-            basis = complex, )
+            basis = real, )
+
+@show length(𝔹basis)            
 
 ##
 
-@profview let mb_spec = nnll_long, Rnl_spec = Rn_spec, Ylm_spec = Ylm_spec, basis = complex 
+@profview let mb_spec = nnll_spec, Rnl_spec = Rn_spec, Ylm_spec = Ylm_spec, basis = real
    𝔹basis = ET.sparse_equivariant_tensor(; 
             L = 0, mb_spec = mb_spec, 
             Rnl_spec = Rnl_spec, Ylm_spec = Ylm_spec, basis = basis )

--- a/examples/ace/simple_ace.jl
+++ b/examples/ace/simple_ace.jl
@@ -94,7 +94,7 @@ myfilter = ii -> begin
       nn, ll, mm = ii2bb(ii);
       return ( (sum(nn + ll; init=0) <= Dtot) &&  # total degree trunction
                iseven(sum(ll; init=0)) &&         # reflection-invariance
-               (length(mm) == 0 || ET.O3.mm_filter(mm, 0, flag=:SpheriCart)) &&         # rotation-invariance
+               (length(mm) == 0 || ET.O3.mm_filter(mm, 0, real)) &&         # rotation-invariance
                sum(ii) > 0 )           # drop 0-corr sure to bug 
    end 
 

--- a/examples/ace/simple_ace_equivariant2.jl
+++ b/examples/ace/simple_ace_equivariant2.jl
@@ -20,7 +20,7 @@ struct SimpleACE4{T, RB, YB, BB, TT}
    trans::TT
 end
 
-function evaluate(m::SimpleACE4, 𝐫::AbstractVector{<: SVector{3}}; basis = complex)
+function evaluate(m::SimpleACE4, 𝐫::AbstractVector{<: SVector{3}})
    # [1] Embeddings: evaluate the Rn and Ylm embeddings
    #   Rn[j] = Rn(norm(𝐫[j])), Ylm[j] = Ylm(Rs[j])
    Rn = P4ML.evaluate(m.rbasis, norm.(𝐫))
@@ -92,8 +92,8 @@ Q, cD = ET.O3.QD_from_angles(1, θ, complex)
 perm = randperm(nX)
 Q𝐫 = Ref(Q) .* 𝐫[perm]
 
-φ  = evaluate(model, 𝐫; basis = complex)
-φQ = evaluate(model, Q𝐫; basis = complex)
+φ  = evaluate(model, 𝐫)
+φQ = evaluate(model, Q𝐫)
 @show cD * φ * cD' ≈ φQ
 
 
@@ -135,6 +135,6 @@ Q, rD = ET.O3.QD_from_angles(1, θ, real)
 perm = randperm(nX)
 Q𝐫 = Ref(Q) .* 𝐫[perm]
 
-φ  = evaluate(model, 𝐫; basis = real)
-φQ = evaluate(model, Q𝐫; basis = real)
+φ  = evaluate(model, 𝐫)
+φQ = evaluate(model, Q𝐫)
 @show rD * φ * rD' ≈ φQ

--- a/src/O3/O3.jl
+++ b/src/O3/O3.jl
@@ -159,6 +159,11 @@ end
 lazy_signed_mmset(mm::SVector{N, T}) where {N, T} = 
         LazySignedMMset(mm, zero(MVector{N, Bool}))
 
+function lazy_signed_mmset(mm::Vector{T}) where {T}
+    N = length(mm) 
+    return lazy_signed_mmset(SVector{N, T}(mm))
+end
+
 function Base.iterate(it::LazySignedMMset{N, T}) where {N, T}
     return iterate(it, 0)
 end

--- a/src/O3/O3.jl
+++ b/src/O3/O3.jl
@@ -418,8 +418,9 @@ function _coupling_coeffs(L::Int, ll::SVector{N, Int}, nn::SVector{N, Int};
             MM_sorted = [ _sort(mm, permutable_blocks) for mm in MM_r ] # sort the mm's within the permutable blocks
             MM_reduced = unique(MM_sorted) # ordered mm's - representatives of the equivalent classes
 
-            
-            D_MM_reduced = Dict(MM_reduced[i] => i for i in 1:length(MM_reduced))
+            # NOTE: this block has a type instability; unclear why.
+            D_MM_reduced = Dict{eltype(MM_reduced), Int}(
+                    MM_reduced[i] => i for i in 1:length(MM_reduced))
         
             FMatrix=zeros(T, r, length(MM_reduced)) # Matrix containing f(m,i)
 

--- a/src/O3/O3.jl
+++ b/src/O3/O3.jl
@@ -424,8 +424,10 @@ function _coupling_coeffs(L::Int, ll::SVector{N, Int}, nn::SVector{N, Int};
             MM_reduced = unique(MM_sorted) # ordered mm's - representatives of the equivalent classes
 
             # NOTE: this block has a type instability; unclear why.
-            D_MM_reduced = Dict{eltype(MM_reduced), Int}(
-                    MM_reduced[i] => i for i in 1:length(MM_reduced))
+            D_MM_reduced = Dict{eltype(MM_reduced), Int}() 
+            for i in 1:length(MM_reduced)
+                D_MM_reduced[MM_reduced[i]] = i
+            end
         
             FMatrix=zeros(T, r, length(MM_reduced)) # Matrix containing f(m,i)
 

--- a/src/O3/O3_utils.jl
+++ b/src/O3/O3_utils.jl
@@ -24,20 +24,20 @@ _Ctran(i::Integer, j::Integer, basis::typeof(complex)) = (i == j)
 
 function _Ctran(i::Integer, j::Integer, basis::typeof(real), 
                 T = ComplexF64)
-	val_list = SVector{4, T}((-1)^(i), im, (-1)^(i+1)*im, 1) / sqrt(2)
+	# val_list = SVector{4, T}((-1)^(i), im, (-1)^(i+1)*im, 1) / sqrt(2)
 	if abs(i) != abs(j)
 		return zero(T)
 	elseif i == j == 0
 		return one(T)
 	elseif i > 0 && j > 0
-		return val_list[1]
+		return T((-1)^i / sqrt(2))
 	elseif i < 0 && j < 0
-		return val_list[2]
+		return im / sqrt(2)
 	elseif i < 0 && j > 0
-		return val_list[3]
+		return (-1)^(i+1)*im / sqrt(2)
    end
    @assert i > 0 && j < 0
-	return val_list[4]
+	return T(1 / sqrt(2))
 end
 
 
@@ -81,7 +81,7 @@ function group_by_abs(MM::Vector{SVector{N,Int}}) where N
    return abs_map
 end
 
-function rAA2cAA(MM_c, MM_r; basis = real)
+function rAA2cAA(MM_c, MM_r)
    # find the abs.(mm) and group
    group_c = group_by_abs(MM_c)
    group_r = group_by_abs(MM_r)
@@ -99,7 +99,7 @@ function rAA2cAA(MM_c, MM_r; basis = real)
    for (key, c_inds) in group_c
       r_inds = group_r[key]
       for i in c_inds, j in r_inds
-         val = Ctran(MM_c[i], MM_r[j], basis)
+         val = Ctran(MM_c[i], MM_r[j], real)
          if abs(val) > 1e-12 
             push!(rows, i)
             push!(cols, j)

--- a/src/O3/O3_utils.jl
+++ b/src/O3/O3_utils.jl
@@ -17,6 +17,7 @@ import PartialWaveFunctions, WignerD
 #                       :CondonShortley => SA[4,3,2,1], 
 #                       :FHIaims => SA[4,2,3,1] )
 
+_Ctran(i::Integer, j::Integer) = _Ctran(i, j, real)
 
 _Ctran(i::Integer, j::Integer, basis::typeof(complex)) = (i == j)
 
@@ -45,11 +46,11 @@ Ctran(l::Int64; basis = real) =
 
 Ctran(mm1::SVector{N,Int}, mm2::SVector{N,Int}, basis = real) where {N} = 
       ( abs.(mm1) == abs.(mm2) 
-         ? prod(_Ctran(mm2[i], mm1[i], basis)' for i in 1:N) 
+         ? conj(prod(_Ctran.(mm2, mm1, basis)))
          : zero(ComplexF64) )
 
 
-Ctran(mm1::Vector{Int}, mm2::Vector{Int}; basis = real) = 
+Ctran(mm1::Vector{Int}, mm2::Vector{Int}, basis = real) = 
       ( abs.(mm1) == abs.(mm2) 
         ? prod(_Ctran(mm2[i], mm1[i], basis)' for i in 1:length(mm1))
         : zero(ComplexF64) )
@@ -82,7 +83,7 @@ function rAA2cAA(MM_c, MM_r; basis = real)
            r_inds = group_r[key]
            for i in c_inds
                for j in r_inds
-                   CC[i, j] = _Ctran(MM_c[i], MM_r[j]; basis=basis)
+                   CC[i, j] = Ctran(MM_c[i], MM_r[j], basis)
                end
            end
        end

--- a/src/O3/O3_utils.jl
+++ b/src/O3/O3_utils.jl
@@ -137,8 +137,8 @@ function _real_clebschgordan(l1, m1, l2, m2, λ, νp)
            # Selection rules: |ν| must be ≤ λ and match |νp|
            if abs(ν) ≤ λ && abs(ν) == abs(νp)
                cg = PartialWaveFunctions.clebschgordan(l1, n1, l2, n2, λ, ν)
-               result += ( Ctran(m1, n1) * conj(Ctran(-m2, -n2))
-                           * conj(Ctran(νp, ν, basis)) * cg )
+               result += ( _Ctran(m1, n1, real) * conj(_Ctran(-m2, -n2, real))
+                           * conj(_Ctran(νp, ν, real)) * cg )
            end
        end
    end

--- a/src/O3/O3_utils.jl
+++ b/src/O3/O3_utils.jl
@@ -24,10 +24,11 @@ _Ctran(i::Integer, j::Integer, basis::typeof(complex)) = (i == j)
 
 function _Ctran(i::Integer, j::Integer, basis::typeof(real))
 	val_list = SA[(-1)^(i), im, (-1)^(i+1)*im, 1] / sqrt(2)
+   T = eltype(val_list)
 	if abs(i) != abs(j)
-		return zero(ComplexF64)
+		return zero(T)
 	elseif i == j == 0
-		return one(ComplexF64)
+		return one(T)
 	elseif i > 0 && j > 0
 		return val_list[1]
 	elseif i < 0 && j < 0
@@ -46,8 +47,8 @@ Ctran(l::Int64; basis = real) =
 
 Ctran(mm1::SVector{N,Int}, mm2::SVector{N,Int}, basis = real) where {N} = 
       ( abs.(mm1) == abs.(mm2) 
-         ? conj(prod(_Ctran.(mm2, mm1, basis)))
-         : zero(ComplexF64) )
+         ? conj(prod(_Ctran(mm2[t], mm1[t], basis) for t = 1:N))
+         : zero(ComplexF64) )::ComplexF64
 
 
 Ctran(mm1::Vector{Int}, mm2::Vector{Int}, basis = real) = 

--- a/src/ace/sparse_ace_utils.jl
+++ b/src/ace/sparse_ace_utils.jl
@@ -146,19 +146,26 @@ end
 """
 takes an nnll spec and generates a complete list of all possible nnllmm
 """
-function _auto_nnllmm_spec(nnll_spec)
+function _auto_nnllmm_spec(nnll_spec, Lmax = Inf)
+   # NOTE: this function is a huge bottleneck of the basis generation code 
+   #       but it appears that it cannot be easily improved. Using sorted 
+   #       inserts is MUCH MUCH slower. Using a Set is also a little bit 
+   #       slower. 
+   #       Consider how to multi-thread it? 
    _sortby(bb) = (length(bb), bb) 
-
    NT_NLM = typeof( (n = 0, l = 0, m = 0) ) 
    nnllmm = Vector{NT_NLM}[] 
    for bb in nnll_spec
       MM = setproduct( [ -b.l:b.l for b in bb ] )
       for mm in eachrow(MM)
-         push!(nnllmm, [ (n = b.n, l = b.l, m = m) 
-                         for (b, m) in zip(bb, mm) ] )
+         # Liwei: is this really correct? 
+         if abs(sum(mm)) > Lmax; continue; end 
+         bb = sort!([ (n = b.n, l = b.l, m = m) for (b, m) in zip(bb, mm) ])
+         push!(nnllmm, bb)
       end
    end
-   return unique(sort( sort!.(nnllmm), by = _sortby ))
+   sort!(nnllmm, by = _sortby)
+   return unique!(nnllmm)
 end
 
 

--- a/src/ace/sparse_ace_utils.jl
+++ b/src/ace/sparse_ace_utils.jl
@@ -146,20 +146,19 @@ end
 """
 takes an nnll spec and generates a complete list of all possible nnllmm
 """
-function _auto_nnllmm_spec(nnll_spec, Lmax = Inf)
+function _auto_nnllmm_spec(nnll_spec)
    # NOTE: this function is a huge bottleneck of the basis generation code 
    #       but it appears that it cannot be easily improved. Using sorted 
    #       inserts is MUCH MUCH slower. Using a Set is also a little bit 
    #       slower. 
-   #       Consider how to multi-thread it? 
+   #       - Consider how to multi-thread it? 
+   #       - or add the mm filter? 
    _sortby(bb) = (length(bb), bb) 
    NT_NLM = typeof( (n = 0, l = 0, m = 0) ) 
    nnllmm = Vector{NT_NLM}[] 
    for bb in nnll_spec
       MM = setproduct( [ -b.l:b.l for b in bb ] )
       for mm in eachrow(MM)
-         # Liwei: is this really correct? 
-         if abs(sum(mm)) > Lmax; continue; end 
          bb = sort!([ (n = b.n, l = b.l, m = m) for (b, m) in zip(bb, mm) ])
          push!(nnllmm, bb)
       end

--- a/src/ace/sparse_ace_utils.jl
+++ b/src/ace/sparse_ace_utils.jl
@@ -159,8 +159,8 @@ function _auto_nnllmm_spec(nnll_spec)
    for bb in nnll_spec
       MM = setproduct( [ -b.l:b.l for b in bb ] )
       for mm in eachrow(MM)
-         bb = sort!([ (n = b.n, l = b.l, m = m) for (b, m) in zip(bb, mm) ])
-         push!(nnllmm, bb)
+         bb1 = sort!([ (n = b.n, l = b.l, m = m) for (b, m) in zip(bb, mm) ])
+         push!(nnllmm, bb1)
       end
    end
    sort!(nnllmm, by = _sortby)

--- a/src/utils/invmap.jl
+++ b/src/utils/invmap.jl
@@ -5,8 +5,11 @@ struct FFInvMap{T, HF}
    hashfcn::HF
 end 
 
-Base.getindex(m::FFInvMap, v) = 
-      m.p[searchsortedfirst(m.h, m.hashfcn(v))]
+function Base.getindex(m::FFInvMap{T}, v) where {T}
+   h = m.hashfcn(v)::T
+   i = searchsortedfirst(m.h, h)
+   return m.p[i]
+end
 
 """
       invmap(a::AbstractVector)
@@ -19,9 +22,10 @@ inva[a[i]] == i  # true for all i
 ```
 """
 function invmap(a::AbstractVector, hashfcn = identity)
-   p = sortperm(a) 
-   h = [ hashfcn(a[p[i]]) for i in 1:length(a) ]
-   if !allunique(h)
+   h = hashfcn.(a)
+   p = sortperm(h) 
+   permute!(h, p)
+   if any(h[i] == h[i+1] for i = 1:length(h)-1)
       throw(ArgumentError("invmap: Elements of a must be unique"))
    end
    return FFInvMap(h, p, hashfcn)

--- a/src/utils/symmop.jl
+++ b/src/utils/symmop.jl
@@ -26,35 +26,17 @@ function symmetrisation_matrix(L::Integer, mb_spec;
    #   Vector{Vector{NT_NLM}}   
    #   where NT_NLM = typeof( (n = 0, l = 0) )
 
-   # generate a first naive 𝔸 specification that doesn't take into account 
-   # any symmetries at all. 
-   # NOTE: this is not efficient and could be done on the fly while generating 
-   #       the symmetrization operator. But for now it works and is easy to use.
-   #
-   # Vector{Vector{NT_NLM}}
-   𝔸spec = _auto_nnllmm_spec(mb_spec)
-   
    # convert an element of 𝔸spec to nn, ll, mm, which is the format 
    # used by the coupling_coeffs function 
-   function _vecnt2nnllmm(bb)
+   function _vecnt2nnll(bb)
       nn = [ b.n for b in bb ]
       ll = [ b.l for b in bb ]
-      mm = [ b.m for b in bb ]
-      return nn, ll, mm
+      return nn, ll
    end
-
-   # convert nn, ll, mm or bb to a unique search key for searching in 𝔸spec
-   _bb_key(nnllmm::Tuple) = _bb_key(nnllmm[1], nnllmm[2], nnllmm[3])
-   _bb_key(nn, ll, mm) = sort([ (nn[i], ll[i], mm[i]) for i = 1:length(nn) ])
-   _bb_key(bb::Vector{@NamedTuple{n::Int, l::Int, m::Int}}) = 
-            sort([ (b.n, b.l, b.m) for b in bb ])
-
-   # create a lookup into 𝔸spec 
-   inv_𝔸spec = invmap(𝔸spec, _bb_key)
 
    # extract all unique (nn, ll) blocks, since the (ll, mm) will only be used 
    # in generating the coupled / symmetrized basis functions
-   nnll = unique( [(nn, ll) for (nn, ll, mm) in _vecnt2nnllmm.(𝔸spec)] )
+   nnll = unique(_vecnt2nnll.(mb_spec))
 
    # Now for each (nn, ll) block we can generate all possible invariant basis 
    # functions. We assemble the symmetrization operator in triplet format, 
@@ -66,18 +48,23 @@ function symmetrisation_matrix(L::Integer, mb_spec;
    irow = Int[]; jcol = Int[]; val = TVAL[]
 
    # counter for total number of equivariant basis functions
+   𝔸spec = Vector{@NamedTuple{n::Int64, l::Int64, m::Int64}}[]
    num𝔹 = 0 
+   num𝔸 = 0
    for (nn, ll) in nnll
       # here the kwargs... should be PI and basis 
       cc, MM = O3.coupling_coeffs(L, ll, nn; kwargs...)
       num_b = size(cc, 1)   
+      if num_b == 0; continue; end
       # lookup the corresponding (nn, ll, mm) in the 𝔸 specification 
       # idx_𝔸 = Int[ inv_𝔸spec[ (nn, ll, mm) ] for mm in MM ] 
       idx_𝔸 = Int[] 
-      for mm in MM 
-         _i = (inv_𝔸spec[ (nn, ll, mm) ])::Int 
-         push!(idx_𝔸, _i)
+      for (_i,mm) in enumerate(MM) 
+         # _i = (inv_𝔸spec[ (nn, ll, mm) ])::Int 
+         push!(idx_𝔸, _i+num𝔸)
+         push!(𝔸spec, [(n = nn[i], l = ll[i], m = mm[i]) for i = 1:length(mm)])
       end
+      num𝔸 += length(MM)
       # add the new basis functions to the triplet format
       for q = 1:num_b 
          num𝔹 += 1
@@ -87,8 +74,9 @@ function symmetrisation_matrix(L::Integer, mb_spec;
       end
    end
 
+   @assert num𝔸 == length(𝔸spec)
    # assemble the symmetrization operator in compressed column format 
-   symm = sparse(irow, jcol, val, num𝔹, length(𝔸spec)) 
+   symm = sparse(irow, jcol, val, num𝔹, num𝔸) 
 
    # prune rows with all-zero entries (if there are any then print a warning 
    # because this indicates a bug in `coupling_coeffs`)

--- a/src/utils/symmop.jl
+++ b/src/utils/symmop.jl
@@ -32,7 +32,7 @@ function symmetrisation_matrix(L::Integer, mb_spec;
    #       the symmetrization operator. But for now it works and is easy to use.
    #
    # Vector{Vector{NT_NLM}}
-   𝔸spec = _auto_nnllmm_spec(mb_spec)
+   𝔸spec = _auto_nnllmm_spec(mb_spec, L)
    
    # convert an element of 𝔸spec to nn, ll, mm, which is the format 
    # used by the coupling_coeffs function 
@@ -45,8 +45,9 @@ function symmetrisation_matrix(L::Integer, mb_spec;
 
    # convert nn, ll, mm or bb to a unique search key for searching in 𝔸spec
    _bb_key(nnllmm::Tuple) = _bb_key(nnllmm[1], nnllmm[2], nnllmm[3])
-   _bb_key(nn, ll, mm) = sort([ (n, l, m) for (n, l, m) in zip(nn, ll, mm) ])
-   _bb_key(bb::Vector{<: NamedTuple}) = sort([ (b.n, b.l, b.m) for b in bb ])
+   _bb_key(nn, ll, mm) = sort([ (nn[i], ll[i], mm[i]) for i = 1:length(nn) ])
+   _bb_key(bb::Vector{@NamedTuple{n::Int, l::Int, m::Int}}) = 
+            sort([ (b.n, b.l, b.m) for b in bb ])
 
    # create a lookup into 𝔸spec 
    inv_𝔸spec = invmap(𝔸spec, _bb_key)
@@ -71,7 +72,12 @@ function symmetrisation_matrix(L::Integer, mb_spec;
       cc, MM = O3.coupling_coeffs(L, ll, nn; kwargs...)
       num_b = size(cc, 1)   
       # lookup the corresponding (nn, ll, mm) in the 𝔸 specification 
-      idx_𝔸 = [inv_𝔸spec[ (nn, ll, mm) ] for mm in MM] 
+      # idx_𝔸 = Int[ inv_𝔸spec[ (nn, ll, mm) ] for mm in MM ] 
+      idx_𝔸 = Int[] 
+      for mm in MM 
+         _i = (inv_𝔸spec[ (nn, ll, mm) ])::Int 
+         push!(idx_𝔸, _i)
+      end
       # add the new basis functions to the triplet format
       for q = 1:num_b 
          num𝔹 += 1

--- a/src/utils/symmop.jl
+++ b/src/utils/symmop.jl
@@ -32,7 +32,7 @@ function symmetrisation_matrix(L::Integer, mb_spec;
    #       the symmetrization operator. But for now it works and is easy to use.
    #
    # Vector{Vector{NT_NLM}}
-   𝔸spec = _auto_nnllmm_spec(mb_spec, L)
+   𝔸spec = _auto_nnllmm_spec(mb_spec)
    
    # convert an element of 𝔸spec to nn, ll, mm, which is the format 
    # used by the coupling_coeffs function 

--- a/src/utils/symmop.jl
+++ b/src/utils/symmop.jl
@@ -44,6 +44,7 @@ function symmetrisation_matrix(L::Integer, mb_spec;
 
    # NB : HACK TO DISTINGUISH L = 0 and L > 0
    #      this should potentially be revisited in the future 
+   #      in fact this might be a type-stability issue
    TVAL = L == 0 ? Float64 : SVector{2*L+1, Float64}
    irow = Int[]; jcol = Int[]; val = TVAL[]
 

--- a/test/test_coupling.jl
+++ b/test/test_coupling.jl
@@ -156,9 +156,9 @@ for L = 0:Lmax
       N = length(ll)
 
       Ure, Mll = coupling_coeffs(L, ll; PI = false) # cSH based re_basis
-      Ure_r, Mll_r = coupling_coeffs(L, ll; PI = false, basis = :SpheriCart) # rSH based re_basis
+      Ure_r, Mll_r = coupling_coeffs(L, ll; PI = false, basis = real) # rSH based re_basis
       Urpe, Mll = coupling_coeffs(L, ll) # cSH based rpe_basis
-      Urpe_r, Mll_r = coupling_coeffs(L, ll; basis = :SpheriCart) # rSH based rpe_basis
+      Urpe_r, Mll_r = coupling_coeffs(L, ll; basis = real) # rSH based rpe_basis
 
       rk = rank(gram(Urpe), rtol = 1e-12)
       rk_r = rank(gram(Urpe_r), rtol = 1e-12)

--- a/test/test_rAA2cAA.jl
+++ b/test/test_rAA2cAA.jl
@@ -59,7 +59,7 @@ for L = 0:Lmax
         # Generate random points on the sphere
         X = [ (0.1 + 0.9 * rand()) * rand_sphere() for i in 1:length(ll) ]
         MM_c = mm_generate(L, ll, nn)
-        MM_r = mm_generate(L, ll, nn; flag = :SpheriCart)
+        MM_r = mm_generate(L, ll, nn; basis = real)
         AA_c = eval_AA_basis(X; MM = MM_c, ll, nn, sym = false)
         AA_r = eval_AA_basis(X; MM = MM_r, ll, nn, Real = true, sym = false)
 

--- a/test/test_representation.jl
+++ b/test/test_representation.jl
@@ -1,5 +1,5 @@
 using Test, EquivariantTensors, StaticArrays, SpheriCart, Combinatorics
-using EquivariantTensors.O3: Ctran
+using EquivariantTensors.O3: Ctran, _Ctran
 using PartialWaveFunctions: clebschgordan
 using LinearAlgebra
 using WignerD, Rotations
@@ -121,12 +121,12 @@ for ntest = 1:30
    for λ = abs(l1-l2):l1+l2, m in unique([m1,-m1]), mm in unique([m2,-m2])
       for μ in unique([μ1,-μ1]), μμ in unique([μ2,-μ2])
          if abs(m+mm) ≤ λ && abs(μ+μμ) ≤ λ
-            c1 = Ctran(m1,m) * Ctran(m2,mm) * Ctran(μ1,μ)' * Ctran(μ2,μμ)'
+            c1 = _Ctran(m1,m) * _Ctran(m2,mm) * _Ctran(μ1,μ)' * _Ctran(μ2,μμ)'
             c2 = clebschgordan(l1,m,l2,mm,λ,m+mm) * clebschgordan(l1,μ,l2,μμ,λ,μ+μμ)
             # val2 += c1 * DDset[l1+1][m+l1+1,μ+l1+1] * DDset[l2+1][mm+l2+1,μμ+l2+1]
             # val2 += c1 * c2 * DDset[λ+1][m+mm+λ+1,μ+μμ+λ+1]
             for p in unique([m+mm,-m-mm]), q in unique([μ+μμ,-μ-μμ])
-               c3 = Ctran(p,m+mm)' * Ctran(q,μ+μμ)
+               c3 = _Ctran(p,m+mm)' * _Ctran(q,μ+μμ)
                val2 += c1 * c2 * c3 * Dset[λ+1][p+λ+1,q+λ+1]
             end
          end


### PR DESCRIPTION
- [x] fix the code style convention of m vs mm and l vs ll 
- [x] fix type instabilities: too many to fix them all, but get a start
- maybe move everything to tuples (won't fix this for now)

So far this is only partially successful, some critical type-instabilities have been removed, but more remain to be addressed in a future PR. 