### PR TITLE
Rewrite Sparse Matrix

### DIFF
--- a/src/ace/sparsemat_ka.jl
+++ b/src/ace/sparsemat_ka.jl
@@ -1,151 +1,122 @@
 
 using SparseArrays: SparseMatrixCSC 
 import LinearAlgebra: mul! 
-import MLDataDevices: AbstractGPUDevice
-using GPUArraysCore: AbstractGPUArray 
-import Adapt  
 
-struct DevSparseMatrixCSR{VECI, VECV}
+
+"""
+   struct SparseMatCSX
+
+Sparse matrix format that is stored in both CSR and CSC, and can be transferred 
+to GPU devices. Matrix multiplication via KernelAbstractions.jl for GPU support
+and uses whichever format (CSR, CSC) is most suitable for a given operation. 
+"""
+struct SparseMatCSX{VECI, VECV}
    m::Int              # Number of rows
    n::Int              # Number of columns
+   # ---------- CSR format 
    rowptr::VECI        # Row i is in rowptr[i]:(rowptr[i+1]-1)
    colval::VECI        # Col indices of stored values
-   nzval::VECV         # Stored values, typically nonzeros
+   nzval_csr::VECV     # Stored values, typically nonzeros
+   # ---------- CSC format
+   colptr::VECI        # Col j is in colptr[j]:(colptr[j+1]-1)
+   rowval::VECI        # Row indices of stored values
+   nzval_csc::VECV     # Stored values, typically nonzeros
 end
 
 
-function DevSparseMatrixCSR(A::SparseMatrixCSC, dev = identity)
+function SparseMatCSX(A::SparseMatrixCSC, dev = identity)
    At = SparseMatrixCSC(permutedims(A)) 
-   return DevSparseMatrixCSR(A.m, A.n, dev(At.colptr), dev(At.rowval), dev(At.nzval))
+   return SparseMatCSX(A.m, A.n, 
+               dev(At.colptr), dev(At.rowval), dev(At.nzval), 
+               dev(A.colptr),  dev(A.rowval),  dev(A.nzval)  )
 end
 
-_floatT(T::Type{<: AbstractFloat}, A::DevSparseMatrixCSR) = 
-   DevSparseMatrixCSR(A.m, A.n, A.rowptr, A.colval, _floatT(T, A.nzval))
+_floatT(T::Type{<: AbstractFloat}, A::SparseMatCSX) = 
+   SparseMatCSX(A.m, A.n, A.rowptr, A.colval, _floatT(T, A.nzval_csr), 
+                             A.colptr, A.rowval, A.nzval_csc)
 
-Base.size(A::DevSparseMatrixCSR) = (A.m, A.n)
-Base.size(A::DevSparseMatrixCSR, i::Integer) = size(A)[i]
-Base.eltype(A::DevSparseMatrixCSR) = eltype(A.nzval)
+Base.size(A::SparseMatCSX) = (A.m, A.n)
+Base.size(A::SparseMatCSX, i::Integer) = size(A)[i]
+Base.eltype(A::SparseMatCSX) = eltype(A.nzval_csr)
 
 # this is not really used (also no unit tests), 
 # but it can be useful for debugging
-function Base.getindex(A::DevSparseMatrixCSR, i::Int, j::Int)
+function Base.getindex(A::SparseMatCSX, i::Int, j::Int)
    @assert 1 <= i <= A.m
    @assert 1 <= j <= A.n
    for idx = A.rowptr[i]:(A.rowptr[i+1]-1)
       if A.colval[idx] == j
-         return A.nzval[idx]
+         return A.nzval_csr[idx]
       end
    end
-   return zero(eltype(A.nzval))
+   return zero(eltype(A.nzval_csr))
 end
 
-function mul(A::DevSparseMatrixCSR, b::AbstractVector)
+function mul(A::SparseMatCSX, b::AbstractVector)
    m, n = A.m, A.n 
-   x = similar(b, (m,))
-   fill!(x, zero(eltype(x)))
+   TX = typeof(zero(eltype(A)) * zero(eltype(b)))
+   x = similar(b, TX, (m,))
+   fill!(x, zero(TX))
    mul!(reshape(x, (:, 1)), A, reshape(b, (:, 1))) 
    return x
 end
 
-function mul(A::DevSparseMatrixCSR, B::AbstractMatrix)
-   TX = typeof(zero(eltype(A.nzval)) * zero(eltype(B)))
+function mul(A::SparseMatCSX, B::AbstractMatrix)
+   TX = typeof(zero(eltype(A)) * zero(eltype(B)))
    X = similar(B, TX, (size(A, 1), size(B, 2)))
    return mul!(X, A, B)
 end
 
-function mul(A::AbstractMatrix, B::DevSparseMatrixCSR, op = *)
-   TX = typeof( op(zero(eltype(A)), zero(eltype(B.nzval))) ) 
+function mul(A::AbstractMatrix, B::SparseMatCSX, op = *)
+   TX = typeof( op(zero(eltype(A)), zero(eltype(B))) )
    X = similar(A, TX, (size(A, 1), size(B, 2)))
    return mul!(X, A, B, op)
 end
 
+#
+# X = A * B where A is sparse, B is dense 
+# this is easiest to implement in CSR format 
+#
+function mul!(X::AbstractMatrix, A::SparseMatCSX, B::AbstractMatrix, op=*)
 
-
-function mul!(X::AbstractMatrix, A::DevSparseMatrixCSR, B::AbstractMatrix)
-
-   @kernel function _mul_ka_sparse!(X, B, rowptr, colval, nzval)
+   @kernel function _mul_ka_sparse_dense!(X, B, rowptr, colval, nzval_csr)
       row, jB = @index(Global, NTuple)
       
       for idx = rowptr[row]:(rowptr[row+1]-1)
          col = colval[idx]
-         X[row, jB] += nzval[idx] * B[col, jB]
+         X[row, jB] += nzval_csr[idx] * B[col, jB]
       end
 
       nothing 
    end
    
    m, n = A.m, A.n 
-   rowptr = A.rowptr
-   colval = A.colval
-   nzval = A.nzval
-
    @assert size(B, 1) == n
    @assert size(X, 1) == m
    @assert size(X, 2) == size(B, 2)
    fill!(X, zero(eltype(X)))
 
-   kernel! = _mul_ka_sparse!(KernelAbstractions.get_backend(X))
-   kernel!(X, B, rowptr, colval, nzval; ndrange = (m, size(B, 2)))
+   kernel! = _mul_ka_sparse_dense!(KernelAbstractions.get_backend(X))
+   kernel!(X, B, A.rowptr, A.colval, A.nzval_csr; ndrange = (m, size(B, 2)))
    return X
 end 
 
 
-# OLD VERSION WHICH HAS PROBLEMS WITH DUAL
-# function mul!(X::AbstractMatrix, A::AbstractMatrix, B::DevSparseMatrixCSR, op=*)
-#    # B = [ row1 ; row2 ; ... ] 
-   
-#    @kernel function _mul_ka_dense_sparse!(X, A, rowptr, colval, nzval)
-#       # X = A * B 
-#       rowA, rowB = @index(Global, NTuple)
-      
-#       for idx = rowptr[rowB]:(rowptr[rowB+1]-1)
-#          colB = colval[idx]
-#          # This needs to be atomic because X[rowA, colB] is updated 
-#          # in parallel; to avoid this, we need to switch to a CSC format 
-#          # we can achieve this by storing A2Bmaps in both formats, one for the 
-#          # forward pass, the other for the backward pass.
-#          @atomic X[rowA, colB] += op(A[rowA, rowB], nzval[idx])
-#       end
+#
+# X = A * B where A is dense, B is sparse 
+# this is easiest to implement in CSC format 
+#
 
-#       nothing 
-#    end
-   
+function mul!(X::AbstractMatrix, A::AbstractMatrix, B::SparseMatCSX, op=*)
+   # B = [ col1 | col2 | ... ] 
 
-#    m, n = size(A)
-#    k = size(B, 2)
-#    rowptr = B.rowptr
-#    colval = B.colval
-#    nzval = B.nzval
-
-#    @assert size(B) == (n, k)
-#    @assert size(X) == (m, k)
-#    fill!(X, zero(eltype(X)))
-
-#    @show eltype(X) 
-#    @show eltype(A) 
-#    @show eltype(nzval)
-
-#    kernel! = _mul_ka_dense_sparse!(KernelAbstractions.get_backend(X))
-#    kernel!(X, A, rowptr, colval, nzval; ndrange = (m, size(B, 1)))
-#    return X
-# end 
-
-
-function mul!(X::AbstractMatrix, A::AbstractMatrix, B::DevSparseMatrixCSR, op=*)
-   # B = [ row1 ; row2 ; ... ] 
-   
-   @kernel function _mul_ka_dense_sparse!(X, A, rowptr, colval, nzval)
+   @kernel function _mul_ka_dense_sparse!(X, A, colptr, rowval, nzval_csc)
       # X = A * B 
-      rowA, rowB = @index(Global, NTuple)
-      
-      for idx = rowptr[rowB]:(rowptr[rowB+1]-1)
-         colB = colval[idx]
-         # This needs to be atomic because X[rowA, colB] is updated 
-         # in parallel; to avoid this, we need to switch to a CSC format 
-         # we can achieve this by storing A2Bmaps in both formats, one for the 
-         # forward pass, the other for the backward pass.
-         # @atomic 
-         X[rowA, colB] += op(A[rowA, rowB], nzval[idx])
+      rowA, colB = @index(Global, NTuple)
+
+      for idx = colptr[colB]:(colptr[colB+1]-1)
+         rowB = rowval[idx]
+         X[rowA, colB] += op(A[rowA, rowB], nzval_csc[idx])
       end
 
       nothing 
@@ -154,18 +125,16 @@ function mul!(X::AbstractMatrix, A::AbstractMatrix, B::DevSparseMatrixCSR, op=*)
 
    m, n = size(A)
    k = size(B, 2)
-   rowptr = B.rowptr
-   colval = B.colval
-   nzval = B.nzval
 
    @assert size(B) == (n, k)
    @assert size(X) == (m, k)
    fill!(X, zero(eltype(X)))
 
    kernel! = _mul_ka_dense_sparse!(KernelAbstractions.get_backend(X))
-   kernel!(X, A, rowptr, colval, nzval; ndrange = (m, size(B, 1)))
+   kernel!(X, A, B.colptr, B.rowval, B.nzval_csc; ndrange = (m, k))
    return X
 end 
+
 
 
 # NOTE: If AA comes in the format of nnodes x nfeatures then we actually need 

--- a/test/ace/test_sparsemat_ka.jl
+++ b/test/ace/test_sparsemat_ka.jl
@@ -9,7 +9,7 @@ include(joinpath(@__DIR__(), "..", "test_utils", "utils_gpu.jl"))
 
 ## 
 
-@info("Testing DevSparseMatrixCSR multiplication")
+@info("Testing SparseMatCSX multiplication")
 
 Random.seed!(6)
 for itest = 1:100 
@@ -20,7 +20,7 @@ for itest = 1:100
    p = 0.01 * (1 + rand())
 
    A = sprand(Float32, m, n, p)
-   A_dev = ET.DevSparseMatrixCSR(A, dev)
+   A_dev = ET.SparseMatCSX(A, dev)
    B = randn(Float32, n, nB) 
    B_dev = dev(B)
    C = randn(Float32, nB, m)
@@ -28,6 +28,7 @@ for itest = 1:100
 
    X = A * B
    X_dev = ET.mul(A_dev, B_dev)
+   KA.synchronize(KA.get_backend(X_dev))
    print_tf(@test X ≈ Array(X_dev))
 
    Y = C * A
@@ -35,4 +36,38 @@ for itest = 1:100
    KA.synchronize(KA.get_backend(Y_dev))
    print_tf(@test Y ≈ Array(Y_dev))
 end
+println() 
+
+##
+#
+# multiplication with dual numbers involved 
+
+import ForwardDiff as FD
+
+@info("Testing SparseMatCSX with duals")
+
+for itest = 1:10
+   local A, B, X, Y   
+   m = rand(50:200)
+   n = rand(100:300)
+   nB = rand(30:100)
+   p = 0.01 * (1 + rand())
+
+   A = sprand(Float32, m, n, p)
+   A_dev = ET.SparseMatCSX(A, dev)
+   B = FD.Dual.(randn(Float32, n, nB), randn(Float32, n, nB))
+   B_dev = dev(B)
+   C = FD.Dual.(randn(Float32, nB, m), randn(Float32, nB, m))
+   C_dev = dev(C)
+
+   X = A * B
+   X_dev = ET.mul(A_dev, B_dev)
+   KA.synchronize(KA.get_backend(X_dev))
+   print_tf(@test X ≈ Array(X_dev))
+
+   Y = C * A
+   Y_dev = ET.mul(C_dev, A_dev)
+   KA.synchronize(KA.get_backend(Y_dev))
+   print_tf(@test Y ≈ Array(Y_dev))
+end 
 println() 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using EquivariantTensors
 using Test
 
 isdefined(Main, :___UTILS_FOR_TESTS___) || include("utils/utils_testO3.jl")
+include(joinpath(@__DIR__(), "..", "test_utils", "utils_gpu.jl"))
 
 ##
 

--- a/test/test_utils/utils_gpu.jl
+++ b/test/test_utils/utils_gpu.jl
@@ -5,7 +5,7 @@ if !isdefined(Main, :___EQT_UTILS_GPU___)
    global __has_cuda = false    
    global __has_roc = false 
    global __has_metal = false
-   global gpu = dev = nothing 
+   global gpu = global dev = nothing 
 
    try    
       using CUDA
@@ -13,7 +13,7 @@ if !isdefined(Main, :___EQT_UTILS_GPU___)
          @info "Using CUDA"
          CUDA.versioninfo()
          global __has_cuda = true
-         gpu = dev = cu 
+         global gpu = global dev = cu 
       else 
          @info("CUDA is not functional")
       end
@@ -28,7 +28,7 @@ if !isdefined(Main, :___EQT_UTILS_GPU___)
             @info "Using AMD"
             AMDGPU.versioninfo()
             global __has_roc = true
-            gpu = dev = gpu_device() 
+            global gpu = global dev = gpu_device() 
          else
             @info("AMDGPU is not functional")
          end
@@ -44,7 +44,7 @@ if !isdefined(Main, :___EQT_UTILS_GPU___)
             @info "Using Metal"
             Metal.versioninfo()
             global __has_metal = true
-            gpu = dev = mtl 
+            global gpu = global dev = mtl 
          else
             @info("Metal is not functional")
          end


### PR DESCRIPTION
Rewrite `DevSparseMatrixCSR` as `DevSparseMatrix` and store it in both CSR and CCR formats. When applying multiplication operations can choose whichever format is most suitable from left or right, transpose or not. 