### PR TITLE
Accelerate the generation of rSH couplings

### DIFF
--- a/src/O3/O3.jl
+++ b/src/O3/O3.jl
@@ -806,10 +806,15 @@ function coupling_coeffs_new(K::Int, ll::AbstractVector{<:Int}, nn::AbstractVect
     T = K == 0 ? Float64 : SVector{2K+1,Float64}
     N = length(ll)
     @assert length(ll) == length(nn)
+
     if K > sum(ll) # if the matrix is square, we can use the nullspace function
         # return null_return(Val(K),μμset) # Matrix{SVector{2K+1, Float64}}(undef, 0, length(μμset)), μμset
         # return Matrix{SVector{2K+1, Float64}}(undef, 0, length(μμset)), μμset
         return zeros(T, 0, 0), SVector{N, Int}[]
+    end
+
+    if all(iszero, ll) && K == 0 # Only in this trivial case we don't have the following matrix
+        return [1;;], [SVector{N, Int}(zeros(N)), ]
     end
     
     M, μμset, mmset = mat(K, ll, nn) # The matrix that we will use to compute the RPI basis

--- a/src/O3/O3.jl
+++ b/src/O3/O3.jl
@@ -405,52 +405,66 @@ function _coupling_coeffs(L::Int, ll::SVector{N, Int}, nn::SVector{N, Int};
             return C, [ mm[inv_perm] for mm in MM ]
         end
     elseif basis === real 
-        MM_r = mm_generate(L, ll, nn; basis=basis) # all admissible mm's
-        Ure_c, MM_c = _coupling_coeffs(L, ll, nn; PI = false, basis=complex)
-        C_r2c = rAA2cAA(SVector{N, Int}.(MM_c),MM_r) 
-        # TODO: coupling_coeffs and mm_generate return different 
-        #       format of MM's which may need to be fixed
-        
-        # Do the transformation to the complex coupling 
-        # because it has a smaller size compared to the real one
-        if L != 0
-            CL = SMatrix{2L+1,2L+1}(Matrix(Ctran(L)))
-            Ure_c = map(u -> CL * u, Ure_c)
-        end
-        Ure_r = real(Ure_c * C_r2c)
-        
         if !PI
+            MM_r = mm_generate(L, ll, nn; basis=basis) # all admissible mm's
+            Ure_c, MM_c = _coupling_coeffs(L, ll, nn; PI = false, basis=complex)
+            C_r2c = rAA2cAA(SVector{N, Int}.(MM_c),MM_r) 
+            # TODO: coupling_coeffs and mm_generate return different 
+            #       format of MM's which may need to be fixed
+            
+            # Do the transformation to the complex coupling 
+            # because it has a smaller size compared to the real one
+            if L != 0
+                CL = SMatrix{2L+1,2L+1}(Matrix(Ctran(L)))
+                Ure_c = map(u -> CL * u, Ure_c)
+            end
+            Ure_r = real(Ure_c * C_r2c)
             return Ure_r, [ mm[inv_perm] for mm in MM_r ]
         else
             S = Sn(nn,ll)
+            MM_r = mm_generate(L, ll, nn; basis=basis) # all admissible mm's
             permutable_blocks = [ Vector([S[i]:S[i+1]-1]...) for i in 1:length(S)-1]
             MM_sorted = [ _sort(mm, permutable_blocks) for mm in MM_r ] # sort the mm's within the permutable blocks
             MM_reduced = unique(MM_sorted) # ordered mm's - representatives of the equivalent classes
 
-            # NOTE: this block has a type instability; unclear why.
-            D_MM_reduced = Dict{eltype(MM_reduced), Int}() 
-            for i in 1:length(MM_reduced)
-                D_MM_reduced[MM_reduced[i]] = i
+            Urpe_c, MM_c = _coupling_coeffs(L, ll, nn, PI = PI, basis=complex)
+            C_r2c = rAA2cAA_PI(SVector{N, Int}.(MM_c),MM_reduced,MM_r,ll,nn) 
+            # TODO: coupling_coeffs and mm_generate return different 
+            #       format of MM's which may need to be fixed
+            
+            # Do the transformation to the complex coupling 
+            # because it has a smaller size compared to the real one
+            if L != 0
+                CL = SMatrix{2L+1,2L+1}(Matrix(Ctran(L)))
+                Urpe_c = map(u -> CL * u, Urpe_c)
             end
-        
-            FMatrix=zeros(T, r, length(MM_reduced)) # Matrix containing f(m,i)
+            Urpe_r = real.(Urpe_c * C_r2c)
+            return Urpe_r, [ mm[inv_perm] for mm in MM_reduced ]
 
-            for (j,mm) in enumerate(MM_r)
-                col = D_MM_reduced[MM_sorted[j]] # avoid looking up the dictionary repeatedly
-                for i in 1:r
-                    FMatrix[i,col] += Ure_r[i,j]
-                end
-            end 
+            # NOTE: this block has a type instability; unclear why.
+            # D_MM_reduced = Dict{eltype(MM_reduced), Int}() 
+            # for i in 1:length(MM_reduced)
+            #     D_MM_reduced[MM_reduced[i]] = i
+            # end
         
-            # Linear dependence
-            U, S, V = svd(gram(FMatrix))
-            # Somehow rank is not working properly here, might be a relative  
-            # tolerance issue.
-            # original code: rank(Diagonal(S); rtol =  1e-12) 
-            rk = findall(x -> x > 1e-12, S) |> length 
-            # return the RE-PI coupling coeffs
-            return Diagonal(sqrt.(S[1:rk])) * U[:, 1:rk]' * FMatrix, 
-                [ mm[inv_perm] for mm in MM_reduced ]
+            # FMatrix=zeros(T, r, length(MM_reduced)) # Matrix containing f(m,i)
+
+            # for (j,mm) in enumerate(MM_r)
+            #     col = D_MM_reduced[MM_sorted[j]] # avoid looking up the dictionary repeatedly
+            #     for i in 1:r
+            #         FMatrix[i,col] += Ure_r[i,j]
+            #     end
+            # end 
+        
+            # # Linear dependence
+            # U, S, V = svd(gram(FMatrix))
+            # # Somehow rank is not working properly here, might be a relative  
+            # # tolerance issue.
+            # # original code: rank(Diagonal(S); rtol =  1e-12) 
+            # rk = findall(x -> x > 1e-12, S) |> length 
+            # # return the RE-PI coupling coeffs
+            # return Diagonal(sqrt.(S[1:rk])) * U[:, 1:rk]' * FMatrix, 
+            #     [ mm[inv_perm] for mm in MM_reduced ]
         end
     end
     error("Unknown basis type: $basis")

--- a/src/O3/O3.jl
+++ b/src/O3/O3.jl
@@ -423,12 +423,8 @@ function _coupling_coeffs(L::Int, ll::SVector{N, Int}, nn::SVector{N, Int};
         else
             S = Sn(nn,ll)
             MM_r = mm_generate(L, ll, nn; basis=basis) # all admissible mm's
-            permutable_blocks = [ Vector([S[i]:S[i+1]-1]...) for i in 1:length(S)-1]
-            MM_sorted = [ _sort(mm, permutable_blocks) for mm in MM_r ] # sort the mm's within the permutable blocks
-            MM_reduced = unique(MM_sorted) # ordered mm's - representatives of the equivalent classes
-
-            Urpe_c, MM_c = _coupling_coeffs(L, ll, nn, PI = PI, basis=complex)
-            C_r2c = rAA2cAA_PI(SVector{N, Int}.(MM_c),MM_reduced,MM_r,ll,nn) 
+            Urpe_c, MM_c = _coupling_coeffs(L, ll, nn, PI = PI, basis=complex) # cSH-based couplings
+            C_r2c, MM_reduced = rAA2cAA_PI(SVector{N, Int}.(MM_c),MM_r,ll,nn) # r2c map and the ordered mm set
             # TODO: coupling_coeffs and mm_generate return different 
             #       format of MM's which may need to be fixed
             

--- a/src/O3/O3.jl
+++ b/src/O3/O3.jl
@@ -801,17 +801,23 @@ function solver_inner(M::AbstractMatrix{T}, mmset::Vector{Vector{Int}}, μμset:
 end
 
 function coupling_coeffs_new(K::Int, ll::AbstractVector{<:Int}, nn::AbstractVector{<:Int})
+    # TODO: notation inconsistency: K and L both represent the order of equivariance
+    # TODO: reconsider if ll and nn here should be made to be SVector{N, Int}
+    T = K == 0 ? Float64 : SVector{2K+1,Float64}
+    N = length(ll)
     @assert length(ll) == length(nn)
     if K > sum(ll) # if the matrix is square, we can use the nullspace function
         # return null_return(Val(K),μμset) # Matrix{SVector{2K+1, Float64}}(undef, 0, length(μμset)), μμset
-        return Matrix{SVector{2K+1, Float64}}(undef, 0, length(μμset)), μμset
+        # return Matrix{SVector{2K+1, Float64}}(undef, 0, length(μμset)), μμset
+        return zeros(T, 0, 0), SVector{N, Int}[]
     end
     
     M, μμset, mmset = mat(K, ll, nn) # The matrix that we will use to compute the RPI basis
 
     if size(M,1) == size(M,2) # if the matrix is square, we return 0 - but this can only happen when K > sum(ll), which is already handled in the beginning of the function, so this is just for safety
         # return null_return(Val(K),μμset) # Matrix{SVector{2K+1, Float64}}(undef, 0, length(μμset)), μμset
-        return Matrix{SVector{2K+1, Float64}}(undef, 0, length(μμset)), μμset
+        # return Matrix{SVector{2K+1, Float64}}(undef, 0, length(μμset)), μμset
+        return zeros(T, 0, 0), SVector{N, Int}[]
     end
 
     # method I: find the null space of the matrix M using nullspace

--- a/src/O3/O3_utils.jl
+++ b/src/O3/O3_utils.jl
@@ -125,15 +125,12 @@ function rAA2cAA_PI(MM_c_ordered, MM_r, ll, nn)
    classes_map = Dict(m => i for (i, m) in enumerate(MM_r_ordered))
 
    for (key, c_inds) in group_c_ordered
-        # Use get() safely in case a key exists in c_ordered but not in r
-        # r_inds = get(group_r, key, Int[]) 
         r_inds = group_r[key]
         if isempty(r_inds)
             continue
         end
 
         for k in r_inds
-            # Compute 'j' ONCE per 'k' instead of inside the 'i' loop
             mm_tmp = _sort(MM_r[k], permutable_blocks)
             if haskey(classes_map,mm_tmp)
                j = classes_map[mm_tmp]
@@ -141,13 +138,11 @@ function rAA2cAA_PI(MM_c_ordered, MM_r, ll, nn)
                push!(MM_r_ordered, mm_tmp)
                j = length(MM_r_ordered)
                classes_map[mm_tmp] = j
-               # @show j, length(MM_r_ordered), MM_r_ordered
             end
             
             for i in c_inds
                val = Ctran(MM_c_ordered[i], MM_r[k], real) 
                
-               # Only store non-zero values to keep the builder arrays lean
                if abs(val) > 1e-12 
                   push!(rows, i)
                   push!(cols, j)
@@ -158,7 +153,6 @@ function rAA2cAA_PI(MM_c_ordered, MM_r, ll, nn)
       end
 
    # return CC
-   # @assert j == length(MM_r_ordered)
    return sparse(rows, cols, vals, length(MM_c_ordered), length(MM_r_ordered)), MM_r_ordered
 end
 

--- a/src/O3/O3_utils.jl
+++ b/src/O3/O3_utils.jl
@@ -112,6 +112,45 @@ function rAA2cAA(MM_c, MM_r)
    return sparse(rows, cols, vals, length(MM_c), length(MM_r))
 end
 
+function rAA2cAA_PI(MM_c_ordered, MM_r_ordered, MM_r, ll, nn)
+   # Same grouping logic
+   classes_map = Dict(m => i for (i, m) in enumerate(MM_r_ordered))
+   group_c_ordered = group_by_abs(MM_c_ordered)
+   group_r = group_by_abs(MM_r)
+
+   S = Sn(nn,ll)
+   permutable_blocks = [ Vector([S[i]:S[i+1]-1]...) for i in 1:length(S)-1]
+
+   rows = Int[]; cols = Int[]; vals = ComplexF64[]
+
+   for (key, c_inds) in group_c_ordered
+        # Use get() safely in case a key exists in c_ordered but not in r
+        # r_inds = get(group_r, key, Int[]) 
+        r_inds = group_r[key]
+        if isempty(r_inds)
+            continue
+        end
+
+        for k in r_inds
+            # Compute 'j' ONCE per 'k' instead of inside the 'i' loop
+            j = classes_map[_sort(MM_r[k], permutable_blocks)]
+            
+            for i in c_inds
+               val = Ctran(MM_c_ordered[i], MM_r[k], real) 
+               
+               # Only store non-zero values to keep the builder arrays lean
+               if abs(val) > 1e-12 
+                  push!(rows, i)
+                  push!(cols, j)
+                  push!(vals, val)
+               end
+            end
+         end
+      end
+
+   # return CC
+   return sparse(rows, cols, vals, length(MM_c_ordered), length(MM_r_ordered))
+end
 
 # -----------------------------------------------------------------
 #  complex and real Clebsch-Gordan coefficients

--- a/src/O3/O3_utils.jl
+++ b/src/O3/O3_utils.jl
@@ -112,9 +112,8 @@ function rAA2cAA(MM_c, MM_r)
    return sparse(rows, cols, vals, length(MM_c), length(MM_r))
 end
 
-function rAA2cAA_PI(MM_c_ordered, MM_r_ordered, MM_r, ll, nn)
+function rAA2cAA_PI(MM_c_ordered, MM_r, ll, nn)
    # Same grouping logic
-   classes_map = Dict(m => i for (i, m) in enumerate(MM_r_ordered))
    group_c_ordered = group_by_abs(MM_c_ordered)
    group_r = group_by_abs(MM_r)
 
@@ -122,6 +121,8 @@ function rAA2cAA_PI(MM_c_ordered, MM_r_ordered, MM_r, ll, nn)
    permutable_blocks = [ Vector([S[i]:S[i+1]-1]...) for i in 1:length(S)-1]
 
    rows = Int[]; cols = Int[]; vals = ComplexF64[]
+   MM_r_ordered = SVector{length(ll), Int}[]
+   classes_map = Dict(m => i for (i, m) in enumerate(MM_r_ordered))
 
    for (key, c_inds) in group_c_ordered
         # Use get() safely in case a key exists in c_ordered but not in r
@@ -133,7 +134,15 @@ function rAA2cAA_PI(MM_c_ordered, MM_r_ordered, MM_r, ll, nn)
 
         for k in r_inds
             # Compute 'j' ONCE per 'k' instead of inside the 'i' loop
-            j = classes_map[_sort(MM_r[k], permutable_blocks)]
+            mm_tmp = _sort(MM_r[k], permutable_blocks)
+            if haskey(classes_map,mm_tmp)
+               j = classes_map[mm_tmp]
+            else
+               push!(MM_r_ordered, mm_tmp)
+               j = length(MM_r_ordered)
+               classes_map[mm_tmp] = j
+               # @show j, length(MM_r_ordered), MM_r_ordered
+            end
             
             for i in c_inds
                val = Ctran(MM_c_ordered[i], MM_r[k], real) 
@@ -149,7 +158,8 @@ function rAA2cAA_PI(MM_c_ordered, MM_r_ordered, MM_r, ll, nn)
       end
 
    # return CC
-   return sparse(rows, cols, vals, length(MM_c_ordered), length(MM_r_ordered))
+   # @assert j == length(MM_r_ordered)
+   return sparse(rows, cols, vals, length(MM_c_ordered), length(MM_r_ordered)), MM_r_ordered
 end
 
 # -----------------------------------------------------------------


### PR DESCRIPTION
This is to extend the new construction #94 to the rSH-based case, and to resolve #95.

Still need to resolve or unify the way the mm classes were generated. 