### PR TITLE
Generic node_grads_from_edge_grads; drop forces_from_edge_grads

### DIFF
--- a/agents/restructure.md
+++ b/agents/restructure.md
@@ -401,9 +401,12 @@ slot-heterogeneous). No general formats now.**
 
 1. Boundary cleanup first (no new functionality): split `src/ace/` into
    `pooling/` + `formats/sparse/`; promote O3+symmop to `groups/`;
-   `graph.jl` → `src/graphs/` (made container-agnostic); move diffnt
-   toward DP, EmbedDP/decpart into a DP-triggered extension, and the
-   bond_len/agnesi-defaults chemistry toward ACEradials (§5).
+   `graph.jl` → `src/graphs/` (made container-agnostic) — this step
+   should also absorb `extensions/atoms.jl` (the `Atoms` system→ETGraph
+   stubs) into `graphs/` and retire the single-file `extensions/`
+   directory (keep the `Atoms` module name; it is the right namespace);
+   move diffnt toward DP, EmbedDP/decpart into a DP-triggered extension,
+   and the bond_len/agnesi-defaults chemistry toward ACEradials (§5).
 2. Settle the format I/O contract on the sparse format (incl. the
    Lux/ChainRules-vs-bespoke-pullback question, §3) and the A storage
    layout question (§4). Behaviour-preserving; existing tests must pass.

--- a/agents/restructure.md
+++ b/agents/restructure.md
@@ -208,11 +208,12 @@ Destination recommendations (per-piece, refined after CO's comments):
   only XState methods go in the extension. Trade-off accepted:
   extension code rides ET's version train.
 - **`extensions/atoms.jl` prototypes + ext/: keep, but split.** The
-  graph half (`interaction_graph`, `nlist2graph`,
-  `forces_from_edge_grads`) is the system→ETGraph entry point and stays
-  with `graphs/`; note `NeighbourListsExt` currently constructs PStates
-  directly — must become container-agnostic (or gain a DP trigger) once
-  DP leaves the hard deps. The chemistry half (`bond_len`, agnesi
+  graph half (`interaction_graph`, `nlist2graph`) is the system→ETGraph
+  entry point and stays with `graphs/`; note `NeighbourListsExt`
+  currently constructs PStates directly — must become container-agnostic
+  (or gain a DP trigger) once DP leaves the hard deps.
+  (`forces_from_edge_grads` was deleted in `restruct_edgegrads`; its
+  generic core replacement is `node_grads_from_edge_grads`, see §10.) The chemistry half (`bond_len`, agnesi
   defaults in `AtomsBaseExt`) belongs with ACEradials (which already
   has `elements.jl`/`transforms.jl`), not ET. Weakdep stubs themselves
   are harmless — no load cost, a dozen empty functions.
@@ -269,6 +270,27 @@ and refinements relative to the plan above:
 - **`NeighbourListsExt` gains DP as a second trigger**
   (`["NeighbourLists", "DecoratedParticles"]`) — took the cheap option;
   making it container-agnostic is deferred to the graphs/ step.
+
+*Trigger analysis (PR `restruct_edgegrads`).* After `restruct_chemistry`,
+ET's only atoms extension is `NeighbourListsExt` = the
+neighbourlist→ETGraph builder, and its trigger
+`["NeighbourLists", "DecoratedParticles"]` is correct:
+  - *NeighbourLists* must be a trigger — the ext calls
+    `NeighbourLists.PairList`; an extension may use only its triggers +
+    the parent's hard deps, and NeighbourLists is deliberately not an ET
+    hard dep.
+  - *AtomsBase* deliberately not a trigger — `AbstractSystem` and every
+    accessor (species/position/cell_vectors/periodicity/Unitful) reach
+    through `NeighbourLists.AtomsBase` (NeighbourLists hard-depends on
+    AtomsBase). An extra trigger would only delay activation (all
+    triggers must load first).
+  - *DecoratedParticles* is a trigger because the ext **constructs
+    PStates** for all edge/node data (per #110, particles must be state
+    types; bare NamedTuples lack tangent arithmetic). Revisit only when
+    the graphs/ step parametrises the edge container.
+  - Transitive loads count, so ACEpotentials-style consumers (hard deps
+    on NeighbourLists + DP) activate it automatically; direct ET script
+    users need `using NeighbourLists, DecoratedParticles`.
 - **`TransSelSplines` signatures relaxed** from
   `AbstractVector{<: XState}` to `AbstractVector` (duck-typed; the
   tangent-arithmetic contract applies, not a container restriction).
@@ -425,6 +447,13 @@ Outstanding items: review `test_lux_models.jl`
 (SelectLinL coverage vs test_splines overlap) before finalizing the
 restructure.
 
+- ACEpotentials forces/virial wrapper: `restruct_edgegrads` deleted
+  `forces_from_edge_grads` and replaced it with the generic core
+  primitive `node_grads_from_edge_grads(G, w_edges)` (position part of
+  the adjoint of `(x, cell) ↦ 𝐫_e`, no force sign). The forces wrapper
+  (apply the `−` sign, units, `AbstractSystem` handling) and the virial
+  (the cell part of the same adjoint) belong in ACEpotentials.jl — to be
+  added there (repo not in this workspace).
 - A storage layout: flat + spec indexing vs per-l blocks vs flat with
   block views (§4). Prototype against CP before committing.
 - Public differentiation API: ChainRules-only surface over in-place

--- a/agents/restructure.md
+++ b/agents/restructure.md
@@ -454,6 +454,14 @@ restructure.
   (apply the `−` sign, units, `AbstractSystem` handling) and the virial
   (the cell part of the same adjoint) belong in ACEpotentials.jl — to be
   added there (repo not in this workspace).
+- **Revisit `node_grads_from_edge_grads` naming + specification.** It is
+  nothing special: it is the standard *pullback of a node → edge
+  operation* (gather `x ↦ 𝐫_e`), and should be designed/named as such —
+  i.e. as one half of a `forward (node→edge) + pullback (edge→node)`
+  pair on the graph, ideally with a ChainRules `rrule` so it composes
+  with AD rather than being a bespoke helper. The current name and
+  ad-hoc signature are placeholders; settle this together with the
+  graphs/ step and the §3 differentiation-API decision.
 - A storage layout: flat + spec indexing vs per-l blocks vs flat with
   block views (§4). Prototype against CP before committing.
 - Public differentiation API: ChainRules-only surface over in-place

--- a/ext/NeighbourListsExt.jl
+++ b/ext/NeighbourListsExt.jl
@@ -44,20 +44,7 @@ function ET.Atoms.nlist2graph(nlist::NeighbourLists.PairList, sys::AbstractSyste
                   graph_data = sys_data)
    @assert G.first == first
 
-   return G 
-end 
-
-function ET.Atoms.forces_from_edge_grads(sys::AbstractSystem, G::ET.ETGraph, ∇E_edges)
-   
-   TFRC = typeof(∇E_edges[1].𝐫)
-   F = zeros(TFRC, length(sys)) 
-
-   for (i, j, e) in zip(G.ii, G.jj, ∇E_edges) 
-      F[i] -= e.𝐫
-      F[j] += e.𝐫
-   end
-
-   return F
+   return G
 end
 
 end

--- a/src/embed/graph.jl
+++ b/src/embed/graph.jl
@@ -151,3 +151,32 @@ function rrule(::typeof(reshape_embedding), ϕ2, X::ETGraph)
 
    return ϕ3, _pb_ϕ
 end
+
+
+"""
+   node_grads_from_edge_grads(G::ETGraph, w_edges) -> Vector
+
+Scatter edge cotangents onto nodes. For an edge `e` running from node
+`i(e)` to node `j(e)`, the edge vector is
+`𝐫_e = x_{j(e)} - x_{i(e)} (+ shift)`, and the adjoint of the map
+`x ↦ 𝐫_e` accumulates
+```
+   ∂x_i = Σ_{e : j(e) = i} w_e  −  Σ_{e : i(e) = i} w_e ,
+```
+where `w_e` is the cotangent (gradient) with respect to `𝐫_e`. This is
+the position part of the adjoint of `(x, cell) ↦ 𝐫_e`; the cell part of
+the same adjoint yields the virial, which is handled downstream (e.g. in
+a forces/virial wrapper in ACEpotentials).
+
+`w_edges` must be an indexable collection of node-vector-shaped
+cotangents (e.g. `SVector{3}`s extracted from edge gradient states); the
+result is a `Vector` with one entry per node, of the same element type.
+"""
+function node_grads_from_edge_grads(G::ETGraph, w_edges)
+   g = zeros(eltype(w_edges), nnodes(G))
+   for (i, j, w) in zip(G.ii, G.jj, w_edges)
+      g[i] -= w
+      g[j] += w
+   end
+   return g
+end

--- a/src/extensions/atoms.jl
+++ b/src/extensions/atoms.jl
@@ -6,11 +6,9 @@ module Atoms
 # Prototypes for NeighbourListExt
 # -----------------------------
 
-function interaction_graph end 
+function interaction_graph end
 
-function nlist2graph end 
-
-function forces_from_edge_grads end
+function nlist2graph end
 
 
 

--- a/test/atoms/test_neighbourlistsext.jl
+++ b/test/atoms/test_neighbourlistsext.jl
@@ -4,11 +4,11 @@
 
 ##
 
-# need to load NeighbourLists to trigger the atoms extension 
-using EquivariantTensors, NeighbourLists, AtomsBase, AtomsBuilder, Unitful, 
-      Test, ACEbase
+# need to load NeighbourLists to trigger the atoms extension
+using EquivariantTensors, NeighbourLists, AtomsBase, AtomsBuilder, Unitful,
+      Test, ACEbase, StaticArrays
 
-using ACEbase.Testing: println_slim, print_tf      
+using ACEbase.Testing: println_slim, print_tf
 import EquivariantTensors as ET
 
 ##
@@ -27,6 +27,30 @@ println_slim(@test cell_vectors(sys) == (G_sys.graph_data.cell .* u"Å"))
 println_slim(@test [ x.𝐫 * u"Å" for x in G_sys.node_data ]  == position(sys, :)) 
 println_slim(@test sort(nlist.i) == sort(G_sys.ii))
 println_slim(@test sort(nlist.j) == sort(G_sys.jj))
+
+##
+
+@info("node_grads_from_edge_grads scatter")
+
+# small hand-checkable graph: 3 nodes, explicit directed edges
+ii = [1, 1, 2, 3]
+jj = [2, 3, 3, 1]
+G = ET.ETGraph(ii, jj)
+w = [ SVector(1.0, 0.0, 0.0), SVector(0.0, 1.0, 0.0),
+      SVector(0.0, 0.0, 1.0), SVector(1.0, 1.0, 1.0) ]
+
+g = ET.node_grads_from_edge_grads(G, w)
+
+# manual scatter: -w on the source node, +w on the target node
+gman = [ zero(SVector{3, Float64}) for _ in 1:3 ]
+for (i, j, we) in zip(ii, jj, w)
+   gman[i] -= we
+   gman[j] += we
+end
+
+println_slim(@test g == gman)
+# every edge contributes ±w, so the total node gradient sums to zero
+println_slim(@test sum(g) ≈ zero(SVector{3, Float64}))
 
 ## 
 


### PR DESCRIPTION
Follow-up to the chemistry move (#113). Answers a question about ET's atoms extension: after #113 the only atoms extension is `NeighbourListsExt` (the neighbourlist → ETGraph builder), already triggered by `["NeighbourLists", "DecoratedParticles"]` — the correct trigger. The trigger analysis is recorded in [restructure.md](https://github.com/ACEsuit/EquivariantTensors.jl/blob/restruct_edgegrads/agents/restructure.md) §5 (NeighbourLists is required; AtomsBase deliberately not a trigger — reached via `NeighbourLists.AtomsBase`; DP needed because the ext builds PStates).

The actionable change is `forces_from_edge_grads`, which was just the adjoint of the topology map `(x, cell) ↦ 𝐫_e`:

- **deleted** `forces_from_edge_grads` (method in `NeighbourListsExt`, stub in `extensions/atoms.jl`)
- **added** `node_grads_from_edge_grads(G::ETGraph, w_edges)` to core `src/embed/graph.jl` — generic, container-agnostic position-gradient scatter, **no force sign** (the deleted function returned +∇E while named "forces" — latent sign confusion)
- forces wrapper (sign, units, `AbstractSystem`) and virial (cell part of the same adjoint) are ACEpotentials' job — flagged in §10
- direct hand-checkable test in `test/atoms/test_neighbourlistsext.jl`

Tests: ET suite green locally (5411/5411).