### PR TITLE
Support NeighbourLists 0.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,12 +27,13 @@ WignerD = "87c4ff3e-34df-11e9-37a7-516cea4e0402"
 WithAlloc = "fb1aa66a-603c-4c1d-9bc4-66947c7b08dd"
 
 [weakdeps]
+AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
 DecoratedParticles = "023d0394-cb16-4d2d-a5c7-724bed42bbb6"
 NeighbourLists = "2fcf5ba9-9ed4-57cf-b73f-ff513e316b9c"
 
 [extensions]
 DecoratedParticlesExt = "DecoratedParticles"
-NeighbourListsExt = ["NeighbourLists", "DecoratedParticles"]
+NeighbourListsExt = ["NeighbourLists", "AtomsBase", "DecoratedParticles"]
 
 [compat]
 ACEbase = "0.4.5"
@@ -54,7 +55,7 @@ Lux = "1"
 LuxCore = "1.2.4"
 MLDataDevices = "1.9.3"
 Metal = "1.9.0"
-NeighbourLists = "0.5.10"
+NeighbourLists = "0.6"
 PartialWaveFunctions = "0.2.0"
 Polynomials4ML = "0.5.6"
 Random = "1.11"

--- a/agents/restructure.md
+++ b/agents/restructure.md
@@ -285,18 +285,26 @@ neighbourlist→ETGraph builder, and its trigger
     `NeighbourLists.PairList`; an extension may use only its triggers +
     the parent's hard deps, and NeighbourLists is deliberately not an ET
     hard dep.
-  - *AtomsBase* deliberately not a trigger — `AbstractSystem` and every
-    accessor (species/position/cell_vectors/periodicity/Unitful) reach
-    through `NeighbourLists.AtomsBase` (NeighbourLists hard-depends on
-    AtomsBase). An extra trigger would only delay activation (all
-    triggers must load first).
+  - *AtomsBase* was not a trigger under NeighbourLists 0.5 —
+    `AbstractSystem` and the accessors reached through
+    `NeighbourLists.AtomsBase` (a hard dep + re-export of NL 0.5).
+    **Superseded by PR `restruct_nlist06`:** NeighbourLists 0.6 dropped
+    AtomsBase as a hard dep and stopped re-exporting it (the
+    `PairList(sys, rcut)` constructor moved into NL's own
+    `NeighbourListsAtomsBaseExt`). So under 0.6 AtomsBase **must** be a
+    trigger — the ext now imports it directly (`ustrip` via AtomsBase's
+    re-export), and the NL sys-constructor activates because AtomsBase
+    (which pulls Unitful transitively) is loaded. Trigger is now
+    `["NeighbourLists", "AtomsBase", "DecoratedParticles"]`; compat
+    bumped to NeighbourLists 0.6 only.
   - *DecoratedParticles* is a trigger because the ext **constructs
     PStates** for all edge/node data (per #110, particles must be state
     types; bare NamedTuples lack tangent arithmetic). Revisit only when
     the graphs/ step parametrises the edge container.
   - Transitive loads count, so ACEpotentials-style consumers (hard deps
-    on NeighbourLists + DP) activate it automatically; direct ET script
-    users need `using NeighbourLists, DecoratedParticles`.
+    on NeighbourLists + AtomsBase + DP) activate it automatically; direct
+    ET script users need `using NeighbourLists, AtomsBase,
+    DecoratedParticles`.
 - **`TransSelSplines` signatures relaxed** from
   `AbstractVector{<: XState}` to `AbstractVector` (duck-typed; the
   tangent-arithmetic contract applies, not a container restriction).

--- a/ext/NeighbourListsExt.jl
+++ b/ext/NeighbourListsExt.jl
@@ -5,8 +5,13 @@ module NeighbourListsExt
 
 using NeighbourLists
 import EquivariantTensors as ET
-import NeighbourLists.AtomsBase: AbstractSystem
-using DecoratedParticles: PState 
+# NeighbourLists 0.6 no longer re-exports AtomsBase/Unitful, so import
+# AtomsBase directly (it re-exports `ustrip`). The `PairList(sys, rcut)`
+# constructor is provided by NeighbourLists' own AtomsBase extension,
+# which activates because AtomsBase is one of our triggers.
+import AtomsBase
+import AtomsBase: AbstractSystem
+using DecoratedParticles: PState
 
 function ET.Atoms.interaction_graph(sys::AbstractSystem, rcut) 
    nlist = NeighbourLists.PairList(sys, rcut)
@@ -14,29 +19,31 @@ function ET.Atoms.interaction_graph(sys::AbstractSystem, rcut)
 end
 
 function ET.Atoms.nlist2graph(nlist::NeighbourLists.PairList, sys::AbstractSystem)
-   ii = copy(nlist.i)
-   jj = copy(nlist.j)
-   first = copy(nlist.first) 
+   # NeighbourLists 0.6 returns Int32 index vectors; keep ETGraph indices
+   # as `Int` (matches `Testing.rand_graph` and the maxneigs::Int field)
+   ii = Int.(nlist.i)
+   jj = Int.(nlist.j)
+   first = copy(nlist.first)
    R_ij = [ NeighbourLists._getR(nlist, n) for n = 1:length(ii) ] 
-   S_i = [ NeighbourLists.AtomsBase.species(sys, i) for i in ii ] 
-   S_j = [ NeighbourLists.AtomsBase.species(sys, j) for j in jj ]
+   S_i = [ AtomsBase.species(sys, i) for i in ii ]
+   S_j = [ AtomsBase.species(sys, j) for j in jj ]
    X_ij = [ PState(𝐫 = 𝐫, z0 = si, z1 = sj, 𝐒 = shift) 
             for (𝐫, si, sj, shift) in zip(R_ij, S_i, S_j, nlist.S) ]
 
    # for node data we use _only_ the atomic species for now so that we 
    # don't even give the option of using position information directly. 
    # ... until we sort out how to best handle this in ET. 
-   X_i = [ PState(𝐫 = NeighbourLists.Unitful.ustrip.(NeighbourLists.AtomsBase.position(sys, i)), 
-                  z = NeighbourLists.AtomsBase.species(sys, i))
+   X_i = [ PState(𝐫 = AtomsBase.ustrip.(AtomsBase.position(sys, i)),
+                  z = AtomsBase.species(sys, i))
            for i = 1:length(sys) ]
 
-   cell_vecs_u = NeighbourLists.AtomsBase.cell_vectors(sys)
-   cell_vecs = ntuple( i -> NeighbourLists.Unitful.ustrip.(cell_vecs_u[i]), 
+   cell_vecs_u = AtomsBase.cell_vectors(sys)
+   cell_vecs = ntuple( i -> AtomsBase.ustrip.(cell_vecs_u[i]),
                        length(cell_vecs_u) )
 
-   sys_data = ( pbc = NeighbourLists.AtomsBase.periodicity(sys), 
+   sys_data = ( pbc = AtomsBase.periodicity(sys),
                cell = cell_vecs
-              )          
+              )
 
    G = ET.ETGraph(ii, jj; 
                   edge_data = X_ij, 


### PR DESCRIPTION
Allows NeighbourLists 0.6 (compat bumped to `0.6`-only). It is not a pure compat bump: 0.6 dropped AtomsBase as a hard dep and stopped re-exporting `AtomsBase`/`Unitful`. The `PairList(sys, rcut)` constructor still exists — it moved into NeighbourLists' own `NeighbourListsAtomsBaseExt` — so the graph builder is unchanged; only the imports and triggers shift.

- `NeighbourListsExt` now `import AtomsBase` directly (`ustrip` via AtomsBase's re-export) instead of through `NeighbourLists.AtomsBase`/`.Unitful`; `PairList(sys, rcut)` and `_getR` are kept as-is
- AtomsBase added as a weakdep + third trigger: `["NeighbourLists", "AtomsBase", "DecoratedParticles"]` (NL's AtomsBase ext activates because AtomsBase — pulling Unitful transitively — is loaded)
- NL 0.6 returns `Int32` index vectors; converted to `Int` in the ext so ETGraph indices stay `Int` (matches `Testing.rand_graph` and the `maxneigs::Int` field) — avoids loosening the core struct contract
- restructure.md §5 trigger note updated: the earlier "AtomsBase deliberately not a trigger" rested on NL 0.5's re-export, which 0.6 removed

Tests: full suite green locally against NeighbourLists v0.6.1 (5433/5433).