### PR TITLE
Document NeighbourListsExt load requirement

### DIFF
--- a/agents/restructure.md
+++ b/agents/restructure.md
@@ -305,6 +305,13 @@ neighbourlist→ETGraph builder, and its trigger
     on NeighbourLists + AtomsBase + DP) activate it automatically; direct
     ET script users need `using NeighbourLists, AtomsBase,
     DecoratedParticles`.
+  - *Decision (CO, PR `restruct_atomsdoc`):* keep the builder as the
+    NeighbourListsExt and **document** the load requirement (docstrings
+    on `Atoms.interaction_graph`/`nlist2graph`). The 3-trigger set is
+    intrinsic (NL engine + AtomsBase system + DP states) and the friction
+    is REPL-only — downstream packages auto-activate. A one-import `lib/`
+    glue package was considered and deferred until the graphs/ builder
+    form settles (same reasoning as the EmbedDP lib-vs-ext call).
 - **`TransSelSplines` signatures relaxed** from
   `AbstractVector{<: XState}` to `AbstractVector` (duck-typed; the
   tangent-arithmetic contract applies, not a container restriction).

--- a/src/graphs/atoms.jl
+++ b/src/graphs/atoms.jl
@@ -3,11 +3,35 @@
 
 module Atoms
 
-# Prototypes for NeighbourListExt
+# Prototypes for NeighbourListsExt
 # -----------------------------
 
+"""
+   interaction_graph(sys, rcut) -> ETGraph
+
+Build an `ETGraph` from an AtomsBase system `sys` with cutoff radius
+`rcut`, using a NeighbourLists pair list. Edge data are `PState`s
+carrying the relative position `𝐫`, the species pair `z0, z1`, and the
+cell shift `𝐒`; node data carry position and species.
+
+The implementation lives in `NeighbourListsExt`, which activates only
+when `NeighbourLists`, `AtomsBase`, and `DecoratedParticles` are all
+loaded (NeighbourLists is the search engine, AtomsBase provides the
+system and its accessors, DecoratedParticles provides the `PState` edge/
+node data). A downstream package depending on those three gets the method
+automatically once they load; in the REPL load all three explicitly,
+e.g. `using EquivariantTensors, NeighbourLists, AtomsBase,
+DecoratedParticles`.
+"""
 function interaction_graph end
 
+"""
+   nlist2graph(nlist, sys) -> ETGraph
+
+Convert an existing NeighbourLists `PairList` `nlist` (built for the
+AtomsBase system `sys`) into an `ETGraph`. Same extension and loading
+requirements as [`interaction_graph`](@ref).
+"""
 function nlist2graph end
 
 


### PR DESCRIPTION
Addresses the "why do I need to load all three of NeighbourLists, AtomsBase, DecoratedParticles?" ergonomics question. Outcome: no lighter mechanism exists (Pkg-extension activation requires all triggers loaded, and all three are genuinely needed — NL engine, AtomsBase system, DP `PState` data), and the friction is REPL-only since downstream packages auto-activate the ext by declaring the deps. Decision: keep the extension, document the requirement.

- docstrings on `Atoms.interaction_graph` / `nlist2graph` ([src/graphs/atoms.jl](src/graphs/atoms.jl)) spelling out that the methods come from `NeighbourListsExt`, which needs all three loaded, and how downstream vs REPL use differ
- restructure.md §5: one-line decision record; a one-import `lib/` glue package considered and deferred until the graphs/ builder form settles

Docs-only (attaches to the existing function stubs). Confirmed the package still loads and the Graphs testset passes (7/7).