### PR TITLE
Unify Agnesi transforms in ACEradials

### DIFF
--- a/lib/ACEradials/ext/AtomsBaseExt/atoms_agnesi.jl
+++ b/lib/ACEradials/ext/AtomsBaseExt/atoms_agnesi.jl
@@ -4,7 +4,6 @@
 
 
 import ACEradials
-import ACEradials: agnesi_params, eval_agnesi
 
 function _rineqcut(zi, zj, rinfactor, rcutfactor)
    req = bond_len(zi, zj)
@@ -34,7 +33,7 @@ function at_agnesi_params(zlist;
             return rcut_def 
          end
       end 
-      error("agnesi_params: illegal format for rcuts parameter.")
+      error("at_agnesi_params: illegal format for rcuts parameter.")
    end 
 
    idx = 0 

--- a/lib/ACEradials/src/agnesi_dp.jl
+++ b/lib/ACEradials/src/agnesi_dp.jl
@@ -1,161 +1,99 @@
 
 # Species-pair-indexed Agnesi transform operating on edge / XState
 # descriptors (moved here from EquivariantTensors, src/transforms/agnesi.jl).
-# NOTE: this duplicates the scalar GeneralizedAgnesiTransform in
-#       transforms.jl with a different calling convention; the two should
-#       be unified in a later pass (see agents/radials.md, §4).
+#
+# This is a thin, multi-species adapter over the scalar Agnesi transform in
+# `transforms.jl` (`GeneralizedAgnesiTransform` / `NormalizedTransform`): for
+# each species pair it stores a scalar `r -> [-1, 1]` transform, and on an
+# edge / XState descriptor it evaluates that transform at `norm(x.𝐫)` with a
+# species-pair parameter lookup. Previously this file carried its own copy of
+# the Agnesi math (`agnesi_params` / `eval_agnesi`); that duplication has been
+# removed (see agents/radials.md §4 and agents/radials_restructure.md §3.2).
 
 using LinearAlgebra: norm
 import EquivariantTensors: DPTransform, symidx, catcat2idx_sym
 
-"""
-   agnesi_params(pcut, pin, rin, req, rcut)
-
-Precompute the parameters for the generalized Agnesi transform, to be used with
-`eval_agnesi`. See docs for ??? for details.
-"""
-function agnesi_params(pcut::Integer, pin::Integer, 
-                        rin::Real, req::Real, rcut::Real)
-   @assert pcut > 0
-   @assert pin > 0
-   @assert pin >= pcut      
-   @assert 0 <= rin < req < rcut
-
-   # compute the parameter that maximizes the slope at r = req 
-   a = (-2 * pin + pcut * (-2 + 4 * pin)) / (pcut + pcut^2 + pin + pin^2)
-   @assert a > 0 
-   # this defines the following transform 
-   #   (setting rin ≡ 0, p = pcut, q = pin ... old notation)
-   # x(r) = \frac{1}{1 + a (r/req)^q / (1 + (r/req)^(q-p))}
-   # x(r) ~ (1+ a (r/req)^p)^(-1) ~ (r/req)^{-p} as r -> ∞ 
-   # x(r) ~ (1 + a (r/req)^q)^(-1) ~ 1 - a (r/req)^q as r -> 0
-   _s(r) = (r - rin) / (req - rin) 
-   _x(r) = ( s = _s(r); 
-             1 / (1 + a * s^pin / (1 + s^(pin - pcut))) )
-
-   # now we want to normalize this to map to [-1, 1]
-   # linear mapping to [-1, 1]
-   #   x -> y(r) = 2 * (x - xin) / (xcut - xin) - 1             
-   #             = b1 * x + b0
-   #  where b1 = 2 / (xcut - xin), b0 = -1 - 2 * xin / (xcut - xin)
-   xin = _x(rin)     # -> -1
-   xcut = _x(rcut)   # -> 1 
-   b1 = 2 / (xcut - xin)
-   b0 = -1 - 2 * xin / (xcut - xin)
-
-   # parameter structure / named-tuple 
-   params = (pin = pin, pcut = pcut, 
-             a = a, b0 = b0, b1 = b1, 
-             rin = rin, req = req)
-   
-   return params 
-end
-
-
-""" 
-   eval_agnesi(r::Real, params)
-
-Evaluate the generalized Agnesi transform at distance r, with parameters 
-provided produced by `agnesi_params`. 
-"""
-function eval_agnesi(r::Real, params::NamedTuple) 
-   pin, pcut, a, b0, b1, rin, req = 
-         params.pin, params.pcut, params.a, params.b0, params.b1, 
-         params.rin, params.req
-
-   s = (r - rin) / (req - rin)
-   x = 1 / (1 + a * s^(pin) / (1 + s^(pin - pcut)))
-   y = max(-1, min(1, b1 * x + b0))
-   return y 
-end
-
-
 
 @doc raw"""
-   agnesi_transform(...)
+   agnesi_transform(categories, rins, reqs, rcuts, pin, pcut)
 
-Construct a generalized Agnesi transform, a layer that implements the operation 
+Construct a multi-species generalized Agnesi transform: a `DPTransform` layer
+that, on an edge / XState descriptor `x`, evaluates a scalar Agnesi transform
+at `r = norm(x.𝐫)`, selecting the per-species-pair parameters via `(x.z0,
+x.z1)`. The scalar transform implements
 ```math
-   y(x) = b_0 + \frac{b_1}{1 + a s^q / (1 + s^(q-p))}
+   y(r) = b_0 + \frac{b_1}{1 + a s^q / (1 + s^{q-p})},
+   \qquad s = \frac{r - r_{\rm in}}{r_{\rm eq} - r_{\rm in}},
 ```
-where 
-```math
-   s = \frac{r - r_{\rm in}}{r_{\rm eq} - r_{\rm in}}, 
-```
-with default `b_0, b_1` such that $r \in [r_{\rm in}, r_{\rm cut}]$ is mapped 
-to `[-1, 1]` and `a` such that $|dy/dr|$ is maximised at $r = r_{\rm eq}$. 
+with `p = pcut`, `q = pin`, default `b_0, b_1` mapping `r ∈ [r_{\rm in},
+r_{\rm cut}]` to `[-1, 1]`, and `a` chosen so that `|dy/dr|` is maximised at
+`r = r_{\rm eq}`.
 
-The transform is constructed to satisfy (assum $r_{\rm in} = 0$)
-```math 
-   y \sim \frac{1}{1 + a (r/r_{\rm eq})^q} \quad \text{as} \quad r \to 0 
-   \quad \text{and} 
-   \quad 
-   y \sim (r/r_{\rm eq})^{-p}  \quad \text{as} r \to \infty.
-```
-
-The values for $p, q, r_{\rm in}, r_{\rm eq}, r_{\rm cut}$ need to be 
-   specified. Typical defaults for $p,q$ are `p = 2, q = 4`. 
+`rins`, `reqs`, `rcuts` may each be a single number (applied to all pairs), a
+`Dict` keyed by `(zi, zj)`, or `nothing` to request the default. Typical
+defaults for `p, q` are `pcut = 2, pin = 4`.
 """
-function agnesi_transform(categories, rins, reqs, rcuts, 
+function agnesi_transform(categories, rins, reqs, rcuts,
                           pin::Integer, pcut::Integer)
 
-   function _dict_from_num(cats, r, rdef) 
-      if r isa Dict 
-         return r 
-      end 
-      if r == nothing 
-         r = rdef 
-      end 
-      if r == nothing 
+   function _dict_from_num(cats, r, rdef)
+      if r isa Dict
+         return r
+      end
+      if r == nothing
+         r = rdef
+      end
+      if r == nothing
          error("cannot have r == rdef == nothing")
       end
 
-      rd = Dict{Tuple, Real}() 
+      rd = Dict{Tuple, Real}()
       for (c1, c2) in Iterators.product(cats, cats)
          rd[(c1, c2)] = r
       end
-      return rd 
-   end 
+      return rd
+   end
 
-   # defaults for rins 
+   # defaults for rins
    rins = _dict_from_num(categories, rins, 0.0)
-   # default for reqs 
+   # default for reqs
    reqs = _dict_from_num(categories, reqs, nothing)
    # default for rcuts
    rcuts = _dict_from_num(categories, rcuts, nothing)
 
-   # create the parameters 
-   #     upper-triangular storage, flattened into a vector 
-   #     use catcat2idx_sym to access 
+   # build a scalar Agnesi transform `r -> [-1, 1]` for each species pair
+   #     upper-triangular storage, flattened into a vector
+   #     use catcat2idx_sym / symidx to access
    NZ = length(categories)
-   params = Vector{Any}(undef, (NZ * (NZ+1)) ÷ 2)  
-   idx = 0 
-   for i in 1:NZ, j in i:NZ 
+   transforms = Vector{Any}(undef, (NZ * (NZ+1)) ÷ 2)
+   idx = 0
+   for i in 1:NZ, j in i:NZ
       # confirm that the indexing is correct
       idx += 1
-      @assert idx == symidx(i, j, NZ)  
-      # build the parameters for zi, zj 
+      @assert idx == symidx(i, j, NZ)
+      # scalar Agnesi transform for the (zi, zj) pair; note the scalar
+      # transform's convention is `agnesi_transform(r0, rcut, p, q)` with
+      # `p = pcut`, `q = pin`, `r0 = req`.
       zi = categories[i]; zj = categories[j]
-      params[idx] = agnesi_params(pcut, pin, 
-                           rins[zi, zj], reqs[zi, zj], rcuts[zi, zj])
+      transforms[idx] = agnesi_transform(reqs[zi, zj], rcuts[zi, zj],
+                                         pcut, pin; rin = rins[zi, zj])
    end
 
-   params = identity.(params)
-   # the params should be all of the same type so can be stored in an 
-   # SVector for efficiency. (is this efficient??)
-   # this will be the reference state for the NTtransform 
-   st = ( zlist = categories, 
-          params = SVector{length(params)}(params), )
+   transforms = identity.(transforms)
+   # the transforms should all be of the same type so can be stored in an
+   # SVector for efficiency. This is the reference state for the DPTransform.
+   st = ( zlist = categories,
+          transforms = SVector{length(transforms)}(transforms), )
 
-   # build the actual transform mapping 
-   #     TODO: allow specification of how to get r, s0, s1 from input x!!!
-   f_agnesi = let 
+   # build the actual transform mapping
+   #     TODO: allow specification of how to get r, z0, z1 from input x!!!
+   f_agnesi = let
       (x, st) -> begin
          r = norm(x.𝐫)
          idx = catcat2idx_sym(st.zlist, x.z0, x.z1)
-         return eval_agnesi(r, st.params[idx])
-      end   
+         return evaluate(st.transforms[idx], r)
+      end
    end
-    
+
    return DPTransform(f_agnesi, st)
 end

--- a/lib/ACEradials/src/transforms.jl
+++ b/lib/ACEradials/src/transforms.jl
@@ -2,13 +2,13 @@
 # Scalar `r -> x ∈ [-1,1]` transforms for the radial bases. Ported from
 # ACEpotentials `src/models/radial_transforms.jl`.
 #
-# NOTE on duplication: ET already provides an Agnesi transform in
-# `src/transforms/agnesi.jl`, but with a different calling convention (it
-# operates on an edge / XState descriptor rather than a scalar distance `r`).
-# These two representations are kept separate for now and should be unified in
-# a later pass (see `agents/radials.md`, §4). The serialization (`write_dict`
-# / `read_dict`) and `Roots`-based inverse transform from the ACEpotentials
-# version are intentionally not ported to avoid new dependencies.
+# These are the single source of the Agnesi math in ACEradials: the
+# species-pair / XState transform in `agnesi_dp.jl` is a thin adapter that
+# stores one `NormalizedTransform` per species pair and evaluates it at
+# `norm(x.𝐫)` (see agents/radials.md §4, agents/radials_restructure.md §3.2).
+# The serialization (`write_dict` / `read_dict`) and `Roots`-based inverse
+# transform from the ACEpotentials version are intentionally not ported to
+# avoid new dependencies.
 
 import ForwardDiff
 

--- a/lib/ACEradials/test/test_agnesi.jl
+++ b/lib/ACEradials/test/test_agnesi.jl
@@ -34,6 +34,18 @@ rand_sphere() = (u = (@SVector randn(3)); u / norm(u))
 rand_x(cats, maxrcut) = PState(𝐫 = (1.1 * maxrcut) * rand() * rand_sphere(),
                z0 = rand(cats), z1 = rand(cats))
 
+# standalone reference for the scalar Agnesi transform that the species-pair
+# `agnesi_transform` now wraps (mirrors GeneralizedAgnesiTransform +
+# NormalizedTransform, incl. the `r <= rin -> x = 1` guard).
+function _agnesi_ref(r, rin, req, rcut, pcut, pin)
+   a = (-2 * pin + pcut * (-2 + 4 * pin)) / (pcut + pcut^2 + pin + pin^2)
+   _x(ρ) = ρ <= rin ? one(a) :
+               (s = (ρ - rin) / (req - rin); 1 / (1 + a * s^pin / (1 + s^(pin - pcut))))
+   xin = _x(rin); xcut = _x(rcut)
+   y = -1 + 2 * (_x(r) - xin) / (xcut - xin)
+   return min(max(-one(y), y), one(y))
+end
+
 function _test_agnesi(trans, cats, pcut, pin, rins, reqs, rcuts)
 
    ps, st = LuxCore.setup(rng, trans)
@@ -41,21 +53,16 @@ function _test_agnesi(trans, cats, pcut, pin, rins, reqs, rcuts)
    maxrcut = maximum(collect(values(rcuts)))
    x = rand_x(cats, maxrcut)
    y = trans(x, ps, st)[1]
-
-   # check against manual implementation
-   p = ACEradials.agnesi_params(pcut, pin, rins[(x.z0, x.z1)],
-                            reqs[(x.z0, x.z1)], rcuts[(x.z0, x.z1)])
    r = norm(x.𝐫)
-   y1 = ACEradials.eval_agnesi(r, p)
 
-   __s(r) = (r - rins[(x.z0, x.z1)]) / (reqs[(x.z0, x.z1)] - rins[(x.z0, x.z1)])
-   __x(s) = 1 / (1 + p.a * s^(pin) / (1 + s^(pin - pcut)))
-   _xin = __x(__s(rins[(x.z0, x.z1)]))
-   _xcut = __x(__s(rcuts[(x.z0, x.z1)]))
-   b1 = 2 / (_xcut - _xin)
-   b0 = -1 - 2 * _xin / (_xcut - _xin)
-   y2 = b1 * __x(__s(r)) + b0
-   y2 = max(-1, min(1, y2))
+   rin = rins[(x.z0, x.z1)]; req = reqs[(x.z0, x.z1)]; rcut = rcuts[(x.z0, x.z1)]
+
+   # the species transform must agree with the scalar primitive it wraps ...
+   t_ij = ACEradials.agnesi_transform(req, rcut, pcut, pin; rin = rin)
+   y1 = t_ij(r)
+
+   # ... and with an independent manual reference
+   y2 = _agnesi_ref(r, rin, req, rcut, pcut, pin)
 
    return y, y1, y2
 end
@@ -86,13 +93,12 @@ for ntest = 1:30
 
    x = rand_x(cats, maxrcut)
 
-   params = ACEradials.agnesi_params(pcut, pin, rins[(x.z0, x.z1)],
-                           reqs[(x.z0, x.z1)], rcuts[(x.z0, x.z1)])
    rin = rins[(x.z0, x.z1)]
    req = reqs[(x.z0, x.z1)]
    rcut = rcuts[(x.z0, x.z1)]
 
-   dy(r) = ForwardDiff.derivative(r -> ACEradials.eval_agnesi(r, params), r)
+   t_ij = ACEradials.agnesi_transform(req, rcut, pcut, pin; rin = rin)
+   dy(r) = ForwardDiff.derivative(r -> t_ij(r), r)
    dy_eq = dy(req)
 
    rr = rin .+ (rcut - rin) * rand(100)


### PR DESCRIPTION
Closes the long-standing Agnesi duplication in ACEradials (step 1 of `agents/radials_restructure.md` §4; settles `agents/radials.md` §4).

## What

The species-pair / XState Agnesi transform in `agnesi_dp.jl` is now a **thin adapter** over the scalar `GeneralizedAgnesiTransform` / `NormalizedTransform` in `transforms.jl`:

- it builds one scalar `r → [-1, 1]` transform per species pair (via the existing `agnesi_transform(r0, rcut, p, q; rin)` method) and stores them in the `SVector` reference state;
- on an edge / XState descriptor it evaluates the selected scalar transform at `norm(x.𝐫)`.

The duplicated math `agnesi_params` / `eval_agnesi` is removed — `transforms.jl` is now the single source of the Agnesi math. As a side benefit the species path picks up the scalar transform's `r ≤ rin → x = 1` guard (Flat below `rin`), which the old `eval_agnesi` lacked.

## Notes

- Pure ACEradials cleanup; no P4ML change, no interface change to the `Rnl` bases.
- `ext/AtomsBaseExt/atoms_agnesi.jl` only *imported* `agnesi_params`/`eval_agnesi` (never called them) — import dropped.
- `test_agnesi.jl` now checks the species transform against (a) the scalar primitive it wraps and (b) an independent manual reference; the slope-maximal-at-`req` test uses the scalar transform's derivative.

## Testing

Full `ACEradials` suite passes locally (371/371, Julia 1.12).